### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Sigil-Core/owners


### PR DESCRIPTION
Add CODEOWNERS for doc-only repo governance (PR-only, owner review).