### PR TITLE
feat: attest Policy 2.1 execution capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ An Intent Attestation is an **Ed25519 (EdDSA) signed JWT** that binds:
 - Audience (`aud = "sigil-sign"` for `/v1/authorize` attestations, or the operator-configured audience for RPC/bundler scoped receipts)
 - Policy hash (`policyHash`) — SHA-256 of the canonical JSON serialization of the evaluated warranty policy, providing deterministic cryptographic binding between the attestation and the exact policy version in effect at issuance time
 - Scope claim (`scope`) — present on RPC/bundler receipts; values are `rpc:write` or `bundler:send`
+- Policy 2.1 execution capability claims (`capabilities` and optional `execution_grant`) when the signer binds an attestation to a trusted structured execution boundary
 
 The attestation proves that a transaction intent passed deterministic policy evaluation (Sigil Lex) at issuance time, and which policy version made that decision.
 
@@ -92,6 +93,8 @@ Verification helpers in this repo strictly enforce:
 - Payload must contain a valid `intent` object
 - `policyHash` must be present and treated as opaque by verifiers; auditors may cross-reference against known warranty.md versions
 - `scope` must be validated if the attestation is being used as an RPC/bundler receipt
+- `capabilities`, when present, must be a list of non-empty capability identifiers
+- `execution_grant`, when present, must bind a policy hash, effect manifest hash, shim, executor, adapter, nonce, and bounded issuance window
 - Signature must verify against a published JWK from `/.well-known/jwks.json`
 
 Algorithms such as HS256, RS256, ES256 are explicitly rejected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./errors.js";
 export type {
   Intent,
+  ExecutionGrantClaim,
   VerifiedAttestation,
   VerifyIntentAttestationOptions,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface VerifiedAttestation {
     iss: string;
     exp: number;
     iat?: number;
-    policyHash?: string;
+    policyHash: string;
     scope?: string;
     capabilities?: string[];
     execution_grant?: ExecutionGrantClaim;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,19 @@ export interface VerifyIntentAttestationOptions {
   trustedIssuers?: string | readonly string[];
 }
 
+export interface ExecutionGrantClaim {
+  policy_hash: string;
+  manifest_sha256: string;
+  shim_id: string;
+  executor_id: string;
+  adapter: string;
+  adapter_version: string;
+  nonce: string;
+  issued_at: number;
+  expires_at: number;
+  repository_id?: string;
+}
+
 export interface VerifiedAttestation {
   protectedHeader: {
     alg: string;
@@ -18,6 +31,10 @@ export interface VerifiedAttestation {
     iss: string;
     exp: number;
     iat?: number;
+    policyHash?: string;
+    scope?: string;
+    capabilities?: string[];
+    execution_grant?: ExecutionGrantClaim;
     [key: string]: unknown;
   };
   intent: Intent;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface VerifiedAttestation {
   claims: {
     iss: string;
     exp: number;
-    iat?: number;
+    iat: number;
     policyHash: string;
     scope?: string;
     capabilities?: string[];

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -224,21 +224,42 @@ const isIssuerClaimError = (
 ): boolean =>
   code === "ERR_JWT_CLAIM_VALIDATION_FAILED" && /iss/i.test(message);
 
-const throwVerificationError = (error: unknown): never => {
-  if (error instanceof SigilVerificationError) throw error;
-  const message = error instanceof Error ? error.message : String(error);
-  const code = (error as { code?: string }).code;
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
-  if (code === "ERR_JWT_EXPIRED") {
-    throw new ExpiredAttestationError();
-  }
-  if (isIssuerClaimError(code, message)) {
-    throw new InvalidIssuerError();
-  }
+const getExactVerificationError = (
+  code: string | undefined
+): SigilVerificationError | undefined => {
+  if (code === "ERR_JWT_EXPIRED") return new ExpiredAttestationError();
   if (code !== undefined && SIGNATURE_ERROR_CODES.has(code)) {
-    throw new InvalidSignatureError();
+    return new InvalidSignatureError();
   }
-  throw new SigilVerificationError(message);
+  return undefined;
+};
+
+const createVerificationError = (error: unknown): SigilVerificationError => {
+  if (error instanceof SigilVerificationError) return error;
+  const message = getErrorMessage(error);
+  const code = (error as { code?: string }).code;
+  const exactError = getExactVerificationError(code);
+  if (exactError !== undefined) return exactError;
+  if (isIssuerClaimError(code, message)) {
+    return new InvalidIssuerError();
+  }
+  return new SigilVerificationError(message);
+};
+
+const throwVerificationError = (error: unknown): never => {
+  throw createVerificationError(error);
+};
+
+const validateIntent = (value: unknown): Intent => {
+  if (!isIntent(value)) {
+    throw new InvalidPayloadError(
+      "Payload missing or invalid intent (requires action: string, targetAddress: string)"
+    );
+  }
+  return value;
 };
 
 const buildProtectedHeader = (
@@ -316,17 +337,12 @@ export const verifyIntentAttestation = async (
   validateTemporalClaims(payload);
 
   // Step 3: Validate intent
-  if (!isIntent(payload.intent)) {
-    throw new InvalidPayloadError(
-      "Payload missing or invalid intent (requires action: string, targetAddress: string)"
-    );
-  }
-
+  const intent = validateIntent(payload.intent);
   const policyClaims = validatePolicyClaims(payload);
 
   return {
     protectedHeader: buildProtectedHeader(protectedHeader),
     claims: buildVerifiedClaims(payload, policyClaims),
-    intent: payload.intent,
+    intent,
   };
 };

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -127,6 +127,9 @@ export async function verifyIntentAttestation(
   if (payload.execution_grant !== undefined && !isExecutionGrant(payload.execution_grant)) {
     throw new InvalidPayloadError("execution_grant claim is malformed");
   }
+  if (isExecutionGrant(payload.execution_grant) && payload.execution_grant.policy_hash !== payload.policyHash) {
+    throw new InvalidPayloadError("execution_grant policy_hash does not match policyHash");
+  }
   if (payload.capabilities !== undefined && (!Array.isArray(payload.capabilities) || payload.capabilities.some((capability) => typeof capability !== "string" || capability.length === 0))) {
     throw new InvalidPayloadError("capabilities claim must be a list of non-empty strings");
   }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -16,6 +16,12 @@ import type {
 
 const DEFAULT_TRUSTED_ISSUERS = ["sigil-core"] as const;
 const CLOCK_TOLERANCE_SECONDS = 5;
+const RECEIPT_SCOPES = new Set(["rpc:write", "bundler:send"]);
+const SIGNATURE_ERROR_CODES = new Set([
+  "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+  "ERR_JWS_INVALID",
+  "ERR_JWT_INVALID",
+]);
 const EXECUTION_GRANT_STRING_FIELDS = [
   "policy_hash",
   "manifest_sha256",
@@ -45,17 +51,17 @@ const normalizeTrustedIssuers = (
   return normalized;
 };
 
-const isIntent = (value: unknown): value is Intent => {
-  if (typeof value !== "object" || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  if (typeof obj.action !== "string") return false;
-  if (typeof obj.targetAddress !== "string") return false;
-  if (obj.amount !== undefined && typeof obj.amount !== "string") return false;
-  return true;
-};
-
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.length > 0;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isIntent = (value: unknown): value is Intent =>
+  isRecord(value) &&
+  typeof value.action === "string" &&
+  typeof value.targetAddress === "string" &&
+  (value.amount === undefined || typeof value.amount === "string");
 
 const hasValidExecutionGrantStrings = (
   candidate: Record<string, unknown>
@@ -98,6 +104,21 @@ const validateExecutionGrantWindow = (grant: ExecutionGrantClaim): void => {
   }
 };
 
+const validateTemporalClaims = (payload: Record<string, unknown>): void => {
+  if (!Number.isSafeInteger(payload.exp)) {
+    throw new InvalidPayloadError("Payload missing or invalid exp");
+  }
+  if (!Number.isSafeInteger(payload.iat)) {
+    throw new InvalidPayloadError("Payload missing or invalid iat");
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if ((payload.iat as number) > now + CLOCK_TOLERANCE_SECONDS) {
+    throw new InvalidPayloadError(
+      "iat claim is beyond the five-second clock tolerance"
+    );
+  }
+};
+
 const validateCapabilities = (value: unknown): string[] | undefined => {
   if (value === undefined) return undefined;
   if (
@@ -111,6 +132,37 @@ const validateCapabilities = (value: unknown): string[] | undefined => {
   return value;
 };
 
+const validateScope = (value: unknown): string | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !RECEIPT_SCOPES.has(value)) {
+    throw new InvalidPayloadError(
+      "scope claim must be rpc:write or bundler:send"
+    );
+  }
+  return value;
+};
+
+const requireExecutionGrantCapabilities = (
+  capabilities: string[] | undefined
+): void => {
+  if (capabilities === undefined || capabilities.length === 0) {
+    throw new InvalidPayloadError(
+      "execution_grant requires at least one capability"
+    );
+  }
+};
+
+const requireExecutionGrantPolicyBinding = (
+  grant: ExecutionGrantClaim,
+  policyHash: string
+): void => {
+  if (grant.policy_hash !== policyHash) {
+    throw new InvalidPayloadError(
+      "execution_grant policy_hash does not match policyHash"
+    );
+  }
+};
+
 const validateBoundExecutionGrant = (
   value: unknown,
   policyHash: string,
@@ -120,16 +172,8 @@ const validateBoundExecutionGrant = (
   if (!isExecutionGrant(value)) {
     throw new InvalidPayloadError("execution_grant claim is malformed");
   }
-  if (capabilities === undefined || capabilities.length === 0) {
-    throw new InvalidPayloadError(
-      "execution_grant requires at least one capability"
-    );
-  }
-  if (value.policy_hash !== policyHash) {
-    throw new InvalidPayloadError(
-      "execution_grant policy_hash does not match policyHash"
-    );
-  }
+  requireExecutionGrantCapabilities(capabilities);
+  requireExecutionGrantPolicyBinding(value, policyHash);
   validateExecutionGrantWindow(value);
   return value;
 };
@@ -174,6 +218,12 @@ const decodeEdDsaHeader = async (
   return header;
 };
 
+const isIssuerClaimError = (
+  code: string | undefined,
+  message: string
+): boolean =>
+  code === "ERR_JWT_CLAIM_VALIDATION_FAILED" && /iss/i.test(message);
+
 const throwVerificationError = (error: unknown): never => {
   if (error instanceof SigilVerificationError) throw error;
   const message = error instanceof Error ? error.message : String(error);
@@ -182,21 +232,44 @@ const throwVerificationError = (error: unknown): never => {
   if (code === "ERR_JWT_EXPIRED") {
     throw new ExpiredAttestationError();
   }
-  if (
-    code === "ERR_JWT_CLAIM_VALIDATION_FAILED" &&
-    message.toLowerCase().includes("iss")
-  ) {
+  if (isIssuerClaimError(code, message)) {
     throw new InvalidIssuerError();
   }
-  const signatureCodes = new Set([
-    "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
-    "ERR_JWS_INVALID",
-    "ERR_JWT_INVALID",
-  ]);
-  if (code !== undefined && signatureCodes.has(code)) {
+  if (code !== undefined && SIGNATURE_ERROR_CODES.has(code)) {
     throw new InvalidSignatureError();
   }
   throw new SigilVerificationError(message);
+};
+
+const buildProtectedHeader = (
+  protectedHeader: Record<string, unknown>
+): VerifiedAttestation["protectedHeader"] => ({
+  alg: protectedHeader.alg as string,
+  ...(protectedHeader.kid !== undefined && {
+    kid: protectedHeader.kid as string,
+  }),
+  ...protectedHeader,
+});
+
+const buildVerifiedClaims = (
+  payload: Record<string, unknown>,
+  policyClaims: ReturnType<typeof validatePolicyClaims>
+): VerifiedAttestation["claims"] => {
+  const claims: VerifiedAttestation["claims"] = {
+    iss: payload.iss as string,
+    exp: payload.exp as number,
+    iat: payload.iat as number,
+    policyHash: policyClaims.policyHash,
+  };
+  const scope = validateScope(payload.scope);
+  if (scope !== undefined) claims.scope = scope;
+  if (policyClaims.capabilities !== undefined) {
+    claims.capabilities = policyClaims.capabilities;
+  }
+  if (policyClaims.executionGrant !== undefined) {
+    claims.execution_grant = policyClaims.executionGrant;
+  }
+  return claims;
 };
 
 const verifyJwt = async (
@@ -240,6 +313,7 @@ export const verifyIntentAttestation = async (
     jwks,
     trustedIssuers
   );
+  validateTemporalClaims(payload);
 
   // Step 3: Validate intent
   if (!isIntent(payload.intent)) {
@@ -250,29 +324,9 @@ export const verifyIntentAttestation = async (
 
   const policyClaims = validatePolicyClaims(payload);
 
-  const iat = typeof payload.iat === "number" ? payload.iat : undefined;
-
   return {
-    protectedHeader: {
-      alg: protectedHeader.alg as string,
-      ...(protectedHeader.kid !== undefined && {
-        kid: protectedHeader.kid as string,
-      }),
-      ...protectedHeader,
-    },
-    claims: {
-      iss: payload.iss as string,
-      exp: payload.exp as number,
-      ...(iat !== undefined && { iat }),
-      policyHash: policyClaims.policyHash,
-      ...(typeof payload.scope === "string" && { scope: payload.scope }),
-      ...(policyClaims.capabilities !== undefined && {
-        capabilities: policyClaims.capabilities,
-      }),
-      ...(policyClaims.executionGrant !== undefined && {
-        execution_grant: policyClaims.executionGrant,
-      }),
-    },
+    protectedHeader: buildProtectedHeader(protectedHeader),
+    claims: buildVerifiedClaims(payload, policyClaims),
     intent: payload.intent,
   };
 };

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -16,10 +16,19 @@ import type {
 
 const DEFAULT_TRUSTED_ISSUERS = ["sigil-core"] as const;
 const CLOCK_TOLERANCE_SECONDS = 5;
+const EXECUTION_GRANT_STRING_FIELDS = [
+  "policy_hash",
+  "manifest_sha256",
+  "shim_id",
+  "executor_id",
+  "adapter",
+  "adapter_version",
+  "nonce",
+] as const;
 
-function normalizeTrustedIssuers(
+const normalizeTrustedIssuers = (
   trustedIssuers: VerifyIntentAttestationOptions["trustedIssuers"]
-): string[] {
+): string[] => {
   const issuerValues =
     trustedIssuers === undefined
       ? DEFAULT_TRUSTED_ISSUERS
@@ -34,85 +43,203 @@ function normalizeTrustedIssuers(
   }
 
   return normalized;
-}
+};
 
-function isIntent(value: unknown): value is Intent {
+const isIntent = (value: unknown): value is Intent => {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
   if (typeof obj.action !== "string") return false;
   if (typeof obj.targetAddress !== "string") return false;
   if (obj.amount !== undefined && typeof obj.amount !== "string") return false;
   return true;
-}
+};
 
-function isExecutionGrant(value: unknown): value is ExecutionGrantClaim {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  const strings = ["policy_hash", "manifest_sha256", "shim_id", "executor_id", "adapter", "adapter_version", "nonce"];
-  if (strings.some((key) => typeof candidate[key] !== "string" || candidate[key] === "")) return false;
-  if (!Number.isSafeInteger(candidate.issued_at) || !Number.isSafeInteger(candidate.expires_at)) return false;
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+const hasValidExecutionGrantStrings = (
+  candidate: Record<string, unknown>
+): boolean =>
+  EXECUTION_GRANT_STRING_FIELDS.every((key) =>
+    isNonEmptyString(candidate[key])
+  );
+
+const hasValidExecutionGrantTimestamps = (
+  candidate: Record<string, unknown>
+): boolean => {
+  if (!Number.isSafeInteger(candidate.issued_at)) return false;
+  if (!Number.isSafeInteger(candidate.expires_at)) return false;
   const issuedAt = candidate.issued_at as number;
   const expiresAt = candidate.expires_at as number;
-  if (expiresAt <= issuedAt || expiresAt - issuedAt > 300) return false;
-  return candidate.repository_id === undefined || typeof candidate.repository_id === "string";
-}
+  return expiresAt > issuedAt && expiresAt - issuedAt <= 300;
+};
 
-export async function verifyIntentAttestation(
-  jwt: string,
-  jwks: unknown,
-  options: VerifyIntentAttestationOptions = {}
-): Promise<VerifiedAttestation> {
-  const trustedIssuers = normalizeTrustedIssuers(options.trustedIssuers);
+const hasValidRepositoryId = (candidate: Record<string, unknown>): boolean =>
+  candidate.repository_id === undefined ||
+  isNonEmptyString(candidate.repository_id);
 
-  // Step 1: Enforce EdDSA before signature verification
+const isExecutionGrant = (value: unknown): value is ExecutionGrantClaim => {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    hasValidExecutionGrantStrings(candidate) &&
+    hasValidExecutionGrantTimestamps(candidate) &&
+    hasValidRepositoryId(candidate)
+  );
+};
+
+const validateExecutionGrantWindow = (grant: ExecutionGrantClaim): void => {
+  const now = Math.floor(Date.now() / 1000);
+  if (
+    grant.expires_at <= now ||
+    grant.issued_at > now + CLOCK_TOLERANCE_SECONDS
+  ) {
+    throw new InvalidPayloadError("execution_grant is expired or not yet valid");
+  }
+};
+
+const validateCapabilities = (value: unknown): string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) ||
+    value.some((capability) => !isNonEmptyString(capability))
+  ) {
+    throw new InvalidPayloadError(
+      "capabilities claim must be a list of non-empty strings"
+    );
+  }
+  return value;
+};
+
+const validateBoundExecutionGrant = (
+  value: unknown,
+  policyHash: string,
+  capabilities: string[] | undefined
+): ExecutionGrantClaim | undefined => {
+  if (value === undefined) return undefined;
+  if (!isExecutionGrant(value)) {
+    throw new InvalidPayloadError("execution_grant claim is malformed");
+  }
+  if (capabilities === undefined || capabilities.length === 0) {
+    throw new InvalidPayloadError(
+      "execution_grant requires at least one capability"
+    );
+  }
+  if (value.policy_hash !== policyHash) {
+    throw new InvalidPayloadError(
+      "execution_grant policy_hash does not match policyHash"
+    );
+  }
+  validateExecutionGrantWindow(value);
+  return value;
+};
+
+const validatePolicyClaims = (
+  payload: Record<string, unknown>
+): {
+  policyHash: string;
+  capabilities?: string[];
+  executionGrant?: ExecutionGrantClaim;
+} => {
+  if (!isNonEmptyString(payload.policyHash)) {
+    throw new InvalidPayloadError("Payload missing or invalid policyHash");
+  }
+  const capabilities = validateCapabilities(payload.capabilities);
+  const executionGrant = validateBoundExecutionGrant(
+    payload.execution_grant,
+    payload.policyHash,
+    capabilities
+  );
+  return {
+    policyHash: payload.policyHash,
+    ...(capabilities !== undefined && { capabilities }),
+    ...(executionGrant !== undefined && { executionGrant }),
+  };
+};
+
+const decodeEdDsaHeader = async (
+  jwt: string
+): Promise<ProtectedHeaderParameters> => {
   let header: ProtectedHeaderParameters;
   try {
     header = await decodeProtectedHeader(jwt);
   } catch {
     throw new SigilVerificationError("Failed to decode JWT header");
   }
-
   if (header.alg !== "EdDSA") {
     throw new InvalidAlgorithmError(
       `Expected alg=EdDSA, got alg=${header.alg}`
     );
   }
+  return header;
+};
 
-  // Step 2: Verify signature + standard claims
-  let payload: Record<string, unknown>;
-  let protectedHeader: Record<string, unknown>;
+const throwVerificationError = (error: unknown): never => {
+  if (error instanceof SigilVerificationError) throw error;
+  const message = error instanceof Error ? error.message : String(error);
+  const code = (error as { code?: string }).code;
 
+  if (code === "ERR_JWT_EXPIRED") {
+    throw new ExpiredAttestationError();
+  }
+  if (
+    code === "ERR_JWT_CLAIM_VALIDATION_FAILED" &&
+    message.toLowerCase().includes("iss")
+  ) {
+    throw new InvalidIssuerError();
+  }
+  const signatureCodes = new Set([
+    "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+    "ERR_JWS_INVALID",
+    "ERR_JWT_INVALID",
+  ]);
+  if (code !== undefined && signatureCodes.has(code)) {
+    throw new InvalidSignatureError();
+  }
+  throw new SigilVerificationError(message);
+};
+
+const verifyJwt = async (
+  jwt: string,
+  jwks: unknown,
+  trustedIssuers: string[]
+): Promise<{
+  payload: Record<string, unknown>;
+  protectedHeader: Record<string, unknown>;
+}> => {
   try {
-    const keySet = createLocalJWKSet(jwks as Parameters<typeof createLocalJWKSet>[0]);
+    const keySet = createLocalJWKSet(
+      jwks as Parameters<typeof createLocalJWKSet>[0]
+    );
     const result = await jwtVerify(jwt, keySet, {
       algorithms: ["EdDSA"],
       issuer: trustedIssuers,
     });
-    payload = result.payload as Record<string, unknown>;
-    protectedHeader = result.protectedHeader as Record<string, unknown>;
-  } catch (err: unknown) {
-    if (err instanceof SigilVerificationError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
-    const code = (err as { code?: string }).code;
-
-    if (code === "ERR_JWT_EXPIRED") {
-      throw new ExpiredAttestationError();
-    }
-    if (
-      code === "ERR_JWT_CLAIM_VALIDATION_FAILED" &&
-      msg.toLowerCase().includes("iss")
-    ) {
-      throw new InvalidIssuerError();
-    }
-    if (
-      code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED" ||
-      code === "ERR_JWS_INVALID" ||
-      code === "ERR_JWT_INVALID"
-    ) {
-      throw new InvalidSignatureError();
-    }
-    throw new SigilVerificationError(msg);
+    return {
+      payload: result.payload as Record<string, unknown>,
+      protectedHeader: result.protectedHeader as Record<string, unknown>,
+    };
+  } catch (error: unknown) {
+    return throwVerificationError(error);
   }
+};
+
+export const verifyIntentAttestation = async (
+  jwt: string,
+  jwks: unknown,
+  options: VerifyIntentAttestationOptions = {}
+): Promise<VerifiedAttestation> => {
+  const trustedIssuers = normalizeTrustedIssuers(options.trustedIssuers);
+
+  // Step 1: Enforce EdDSA before signature verification
+  await decodeEdDsaHeader(jwt);
+
+  // Step 2: Verify signature + standard claims
+  const { payload, protectedHeader } = await verifyJwt(
+    jwt,
+    jwks,
+    trustedIssuers
+  );
 
   // Step 3: Validate intent
   if (!isIntent(payload.intent)) {
@@ -121,28 +248,7 @@ export async function verifyIntentAttestation(
     );
   }
 
-  if (typeof payload.policyHash !== "string" || payload.policyHash.length === 0) {
-    throw new InvalidPayloadError("Payload missing or invalid policyHash");
-  }
-
-  if (payload.execution_grant !== undefined && !isExecutionGrant(payload.execution_grant)) {
-    throw new InvalidPayloadError("execution_grant claim is malformed");
-  }
-  if (isExecutionGrant(payload.execution_grant) && payload.execution_grant.policy_hash !== payload.policyHash) {
-    throw new InvalidPayloadError("execution_grant policy_hash does not match policyHash");
-  }
-  if (isExecutionGrant(payload.execution_grant)) {
-    const now = Math.floor(Date.now() / 1000);
-    if (
-      payload.execution_grant.expires_at <= now ||
-      payload.execution_grant.issued_at > now + CLOCK_TOLERANCE_SECONDS
-    ) {
-      throw new InvalidPayloadError("execution_grant is expired or not yet valid");
-    }
-  }
-  if (payload.capabilities !== undefined && (!Array.isArray(payload.capabilities) || payload.capabilities.some((capability) => typeof capability !== "string" || capability.length === 0))) {
-    throw new InvalidPayloadError("capabilities claim must be a list of non-empty strings");
-  }
+  const policyClaims = validatePolicyClaims(payload);
 
   const iat = typeof payload.iat === "number" ? payload.iat : undefined;
 
@@ -158,11 +264,15 @@ export async function verifyIntentAttestation(
       iss: payload.iss as string,
       exp: payload.exp as number,
       ...(iat !== undefined && { iat }),
-      policyHash: payload.policyHash,
+      policyHash: policyClaims.policyHash,
       ...(typeof payload.scope === "string" && { scope: payload.scope }),
-      ...(Array.isArray(payload.capabilities) && { capabilities: payload.capabilities as string[] }),
-      ...(isExecutionGrant(payload.execution_grant) && { execution_grant: payload.execution_grant }),
+      ...(policyClaims.capabilities !== undefined && {
+        capabilities: policyClaims.capabilities,
+      }),
+      ...(policyClaims.executionGrant !== undefined && {
+        execution_grant: policyClaims.executionGrant,
+      }),
     },
     intent: payload.intent,
   };
-}
+};

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -50,6 +50,9 @@ function isExecutionGrant(value: unknown): value is ExecutionGrantClaim {
   const strings = ["policy_hash", "manifest_sha256", "shim_id", "executor_id", "adapter", "adapter_version", "nonce"];
   if (strings.some((key) => typeof candidate[key] !== "string" || candidate[key] === "")) return false;
   if (!Number.isSafeInteger(candidate.issued_at) || !Number.isSafeInteger(candidate.expires_at)) return false;
+  const issuedAt = candidate.issued_at as number;
+  const expiresAt = candidate.expires_at as number;
+  if (expiresAt <= issuedAt || expiresAt - issuedAt > 300) return false;
   return candidate.repository_id === undefined || typeof candidate.repository_id === "string";
 }
 
@@ -117,6 +120,10 @@ export async function verifyIntentAttestation(
     );
   }
 
+  if (typeof payload.policyHash !== "string" || payload.policyHash.length === 0) {
+    throw new InvalidPayloadError("Payload missing or invalid policyHash");
+  }
+
   if (payload.execution_grant !== undefined && !isExecutionGrant(payload.execution_grant)) {
     throw new InvalidPayloadError("execution_grant claim is malformed");
   }
@@ -138,7 +145,7 @@ export async function verifyIntentAttestation(
       iss: payload.iss as string,
       exp: payload.exp as number,
       ...(iat !== undefined && { iat }),
-      ...(typeof payload.policyHash === "string" && { policyHash: payload.policyHash }),
+      policyHash: payload.policyHash,
       ...(typeof payload.scope === "string" && { scope: payload.scope }),
       ...(Array.isArray(payload.capabilities) && { capabilities: payload.capabilities as string[] }),
       ...(isExecutionGrant(payload.execution_grant) && { execution_grant: payload.execution_grant }),

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -9,6 +9,7 @@ import {
 } from "./errors.js";
 import type {
   Intent,
+  ExecutionGrantClaim,
   VerifiedAttestation,
   VerifyIntentAttestationOptions,
 } from "./types.js";
@@ -41,6 +42,15 @@ function isIntent(value: unknown): value is Intent {
   if (typeof obj.targetAddress !== "string") return false;
   if (obj.amount !== undefined && typeof obj.amount !== "string") return false;
   return true;
+}
+
+function isExecutionGrant(value: unknown): value is ExecutionGrantClaim {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  const strings = ["policy_hash", "manifest_sha256", "shim_id", "executor_id", "adapter", "adapter_version", "nonce"];
+  if (strings.some((key) => typeof candidate[key] !== "string" || candidate[key] === "")) return false;
+  if (!Number.isSafeInteger(candidate.issued_at) || !Number.isSafeInteger(candidate.expires_at)) return false;
+  return candidate.repository_id === undefined || typeof candidate.repository_id === "string";
 }
 
 export async function verifyIntentAttestation(
@@ -107,6 +117,13 @@ export async function verifyIntentAttestation(
     );
   }
 
+  if (payload.execution_grant !== undefined && !isExecutionGrant(payload.execution_grant)) {
+    throw new InvalidPayloadError("execution_grant claim is malformed");
+  }
+  if (payload.capabilities !== undefined && (!Array.isArray(payload.capabilities) || payload.capabilities.some((capability) => typeof capability !== "string" || capability.length === 0))) {
+    throw new InvalidPayloadError("capabilities claim must be a list of non-empty strings");
+  }
+
   const iat = typeof payload.iat === "number" ? payload.iat : undefined;
 
   return {
@@ -121,6 +138,10 @@ export async function verifyIntentAttestation(
       iss: payload.iss as string,
       exp: payload.exp as number,
       ...(iat !== undefined && { iat }),
+      ...(typeof payload.policyHash === "string" && { policyHash: payload.policyHash }),
+      ...(typeof payload.scope === "string" && { scope: payload.scope }),
+      ...(Array.isArray(payload.capabilities) && { capabilities: payload.capabilities as string[] }),
+      ...(isExecutionGrant(payload.execution_grant) && { execution_grant: payload.execution_grant }),
     },
     intent: payload.intent,
   };

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -16,6 +16,7 @@ import type {
 
 const DEFAULT_TRUSTED_ISSUERS = ["sigil-core"] as const;
 const CLOCK_TOLERANCE_SECONDS = 5;
+const MAX_ATTESTATION_LIFETIME_SECONDS = 60;
 const RECEIPT_SCOPES = new Set(["rpc:write", "bundler:send"]);
 const SIGNATURE_ERROR_CODES = new Set([
   "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
@@ -111,8 +112,15 @@ const validateTemporalClaims = (payload: Record<string, unknown>): void => {
   if (!Number.isSafeInteger(payload.iat)) {
     throw new InvalidPayloadError("Payload missing or invalid iat");
   }
+  const exp = payload.exp as number;
+  const iat = payload.iat as number;
+  if (exp <= iat || exp - iat > MAX_ATTESTATION_LIFETIME_SECONDS) {
+    throw new InvalidPayloadError(
+      "attestation lifetime must be between one and 60 seconds"
+    );
+  }
   const now = Math.floor(Date.now() / 1000);
-  if ((payload.iat as number) > now + CLOCK_TOLERANCE_SECONDS) {
+  if (iat > now + CLOCK_TOLERANCE_SECONDS) {
     throw new InvalidPayloadError(
       "iat claim is beyond the five-second clock tolerance"
     );
@@ -308,6 +316,8 @@ const verifyJwt = async (
     const result = await jwtVerify(jwt, keySet, {
       algorithms: ["EdDSA"],
       issuer: trustedIssuers,
+      // The five-second tolerance is normative for future iat values only.
+      // Expired attestations fail immediately and receive no clock tolerance.
     });
     return {
       payload: result.payload as Record<string, unknown>,

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -105,26 +105,39 @@ const validateExecutionGrantWindow = (grant: ExecutionGrantClaim): void => {
   }
 };
 
-const validateTemporalClaims = (payload: Record<string, unknown>): void => {
-  if (!Number.isSafeInteger(payload.exp)) {
-    throw new InvalidPayloadError("Payload missing or invalid exp");
+const requireSafeIntegerClaim = (
+  payload: Record<string, unknown>,
+  claim: "exp" | "iat"
+): number => {
+  const value = payload[claim];
+  if (!Number.isSafeInteger(value)) {
+    throw new InvalidPayloadError(`Payload missing or invalid ${claim}`);
   }
-  if (!Number.isSafeInteger(payload.iat)) {
-    throw new InvalidPayloadError("Payload missing or invalid iat");
-  }
-  const exp = payload.exp as number;
-  const iat = payload.iat as number;
+  return value as number;
+};
+
+const validateAttestationLifetime = (exp: number, iat: number): void => {
   if (exp <= iat || exp - iat > MAX_ATTESTATION_LIFETIME_SECONDS) {
     throw new InvalidPayloadError(
       "attestation lifetime must be between one and 60 seconds"
     );
   }
+};
+
+const validateIssuedAt = (iat: number): void => {
   const now = Math.floor(Date.now() / 1000);
   if (iat > now + CLOCK_TOLERANCE_SECONDS) {
     throw new InvalidPayloadError(
       "iat claim is beyond the five-second clock tolerance"
     );
   }
+};
+
+const validateTemporalClaims = (payload: Record<string, unknown>): void => {
+  const exp = requireSafeIntegerClaim(payload, "exp");
+  const iat = requireSafeIntegerClaim(payload, "iat");
+  validateAttestationLifetime(exp, iat);
+  validateIssuedAt(iat);
 };
 
 const validateCapabilities = (value: unknown): string[] | undefined => {
@@ -235,6 +248,11 @@ const isIssuerClaimError = (
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const getErrorCode = (error: unknown): string | undefined => {
+  if (!isRecord(error)) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+};
+
 const getExactVerificationError = (
   code: string | undefined
 ): SigilVerificationError | undefined => {
@@ -248,7 +266,7 @@ const getExactVerificationError = (
 const createVerificationError = (error: unknown): SigilVerificationError => {
   if (error instanceof SigilVerificationError) return error;
   const message = getErrorMessage(error);
-  const code = (error as { code?: string }).code;
+  const code = getErrorCode(error);
   const exactError = getExactVerificationError(code);
   if (exactError !== undefined) return exactError;
   if (isIssuerClaimError(code, message)) {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -26,7 +26,7 @@ describe("verifyIntentAttestation", () => {
   it("verifies a valid EdDSA token", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({ intent: VALID_INTENT, policyHash: "policy-hash" })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
       .setExpirationTime("1h")
@@ -45,7 +45,7 @@ describe("verifyIntentAttestation", () => {
   it("accepts a token from a configured trusted issuer", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({ intent: VALID_INTENT, policyHash: "policy-hash" })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("consortium-issuer")
       .setExpirationTime("1h")

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -5,6 +5,7 @@ import {
   InvalidAlgorithmError,
   ExpiredAttestationError,
   InvalidIssuerError,
+  InvalidPayloadError,
 } from "../src/errors.js";
 
 const VALID_INTENT = {
@@ -56,6 +57,49 @@ describe("verifyIntentAttestation", () => {
     });
 
     expect(result.claims.iss).toBe("consortium-issuer");
+  });
+
+  it("preserves and validates Policy 2.1 execution capability claims", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const executionGrant = {
+      policy_hash: "policy-hash",
+      manifest_sha256: "sha256:manifest",
+      shim_id: "shim-1",
+      executor_id: "executor-1",
+      adapter: "structured-tool",
+      adapter_version: "2.1.0",
+      nonce: "nonce-1",
+      issued_at: Math.floor(Date.now() / 1000),
+      expires_at: Math.floor(Date.now() / 1000) + 30,
+    };
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite", "git.push_fast_forward"],
+      execution_grant: executionGrant,
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(privateKey);
+
+    const result = await verifyIntentAttestation(jwt, jwks);
+    expect(result.claims.policyHash).toBe("policy-hash");
+    expect(result.claims.capabilities).toEqual(["filesystem.overwrite", "git.push_fast_forward"]);
+    expect(result.claims.execution_grant).toEqual(executionGrant);
+  });
+
+  it("rejects malformed capability claims", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({ intent: VALID_INTENT, capabilities: ["filesystem.overwrite", 4] })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(InvalidPayloadError);
   });
 
   it("rejects a token signed with HS256 (wrong algorithm)", async () => {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { generateKeyPair, exportJWK, SignJWT, importJWK } from "jose";
 import { verifyIntentAttestation } from "../src/verify.js";
 import {
@@ -42,6 +42,14 @@ const makeExecutionGrant = (overrides: Record<string, unknown> = {}) => {
   };
 };
 
+const makeExecutionGrantWithWindow = (durationSeconds: number) => {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  return makeExecutionGrant({
+    issued_at: issuedAt,
+    expires_at: issuedAt + durationSeconds,
+  });
+};
+
 const MALFORMED_EXECUTION_GRANTS: Array<[string, unknown]> = [
   ["non-object payload", "not-an-object"],
   ...REQUIRED_EXECUTION_GRANT_FIELDS.flatMap(
@@ -54,11 +62,11 @@ const MALFORMED_EXECUTION_GRANTS: Array<[string, unknown]> = [
   ["non-integer expires_at", makeExecutionGrant({ expires_at: 1.5 })],
   [
     "non-positive window",
-    makeExecutionGrant({ issued_at: 100, expires_at: 100 }),
+    makeExecutionGrantWithWindow(0),
   ],
   [
     "window longer than 300 seconds",
-    makeExecutionGrant({ issued_at: 100, expires_at: 401 }),
+    makeExecutionGrantWithWindow(301),
   ],
   ["invalid repository_id", makeExecutionGrant({ repository_id: 42 })],
   ["empty repository_id", makeExecutionGrant({ repository_id: "" })],
@@ -79,7 +87,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({ intent: VALID_INTENT, policyHash: "policy-hash" })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -98,7 +106,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({ intent: VALID_INTENT, policyHash: "policy-hash" })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("consortium-issuer")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -130,7 +138,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -151,7 +159,7 @@ describe("verifyIntentAttestation", () => {
       })
         .setProtectedHeader({ alg: "EdDSA" })
         .setIssuer("sigil-core")
-        .setExpirationTime("1h")
+        .setExpirationTime("60s")
         .setIssuedAt()
         .sign(privateKey);
 
@@ -171,7 +179,7 @@ describe("verifyIntentAttestation", () => {
       })
         .setProtectedHeader({ alg: "EdDSA" })
         .setIssuer("sigil-core")
-        .setExpirationTime("1h")
+        .setExpirationTime("60s")
         .setIssuedAt()
         .sign(privateKey);
 
@@ -190,7 +198,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -217,7 +225,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -245,7 +253,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -275,7 +283,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -305,7 +313,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -323,7 +331,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .setIssuedAt()
       .sign(privateKey);
 
@@ -356,7 +364,7 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
       .sign(privateKey);
 
     await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
@@ -365,23 +373,50 @@ describe("verifyIntentAttestation", () => {
   });
 
   it("rejects a token issued beyond the five-second clock tolerance", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-24T17:00:00Z"));
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
-    const jwt = await new SignJWT({
-      intent: VALID_INTENT,
-      policyHash: "policy-hash",
-    })
-      .setProtectedHeader({ alg: "EdDSA" })
-      .setIssuer("sigil-core")
-      .setExpirationTime("1h")
-      .setIssuedAt(Math.floor(Date.now() / 1000) + 6)
-      .sign(privateKey);
+    try {
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("60s")
+        .setIssuedAt(Math.floor(Date.now() / 1000) + 6)
+        .sign(privateKey);
 
-    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
-      "iat claim is beyond the five-second clock tolerance"
-    );
+      await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+        "iat claim is beyond the five-second clock tolerance"
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("allows the documented five-second JWT issuance clock tolerance", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-24T17:00:00Z"));
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    try {
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("60s")
+        .setIssuedAt(Math.floor(Date.now() / 1000) + 5)
+        .sign(privateKey);
+
+      await expect(verifyIntentAttestation(jwt, jwks)).resolves.toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects an attestation lifetime longer than 60 seconds", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
@@ -389,11 +424,13 @@ describe("verifyIntentAttestation", () => {
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
-      .setIssuedAt(Math.floor(Date.now() / 1000) + 5)
+      .setExpirationTime("61s")
+      .setIssuedAt()
       .sign(privateKey);
 
-    await expect(verifyIntentAttestation(jwt, jwks)).resolves.toBeDefined();
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+      "attestation lifetime must be between one and 60 seconds"
+    );
   });
 
   it.each(MALFORMED_EXECUTION_GRANTS)(
@@ -408,7 +445,7 @@ describe("verifyIntentAttestation", () => {
       })
         .setProtectedHeader({ alg: "EdDSA" })
         .setIssuer("sigil-core")
-        .setExpirationTime("1h")
+        .setExpirationTime("60s")
         .setIssuedAt()
         .sign(privateKey);
 
@@ -433,7 +470,7 @@ describe("verifyIntentAttestation", () => {
       })
         .setProtectedHeader({ alg: "EdDSA" })
         .setIssuer("sigil-core")
-        .setExpirationTime("1h")
+        .setExpirationTime("60s")
         .setIssuedAt()
         .sign(privateKey);
 
@@ -446,10 +483,14 @@ describe("verifyIntentAttestation", () => {
   it("rejects a token signed with HS256 (wrong algorithm)", async () => {
     const secret = new TextEncoder().encode("super-secret-key-that-is-long-enough");
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
+      .setIssuedAt()
       .sign(secret);
 
     const { jwks } = await makeEdDSAKeypairAndJWKS();
@@ -459,13 +500,17 @@ describe("verifyIntentAttestation", () => {
     );
   });
 
-  it("rejects an expired token", async () => {
+  it("rejects an expired token without expiration clock tolerance", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
       .setExpirationTime("-1s")
+      .setIssuedAt()
       .sign(privateKey);
 
     await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
@@ -476,10 +521,14 @@ describe("verifyIntentAttestation", () => {
   it("rejects a token with the wrong issuer", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("not-sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
+      .setIssuedAt()
       .sign(privateKey);
 
     await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
@@ -490,10 +539,14 @@ describe("verifyIntentAttestation", () => {
   it("rejects an empty trusted issuer set", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
 
-    const jwt = await new SignJWT({ intent: VALID_INTENT })
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
+      .setExpirationTime("60s")
+      .setIssuedAt()
       .sign(privateKey);
 
     await expect(

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -14,6 +14,54 @@ const VALID_INTENT = {
   amount: "1.5",
 };
 
+const REQUIRED_EXECUTION_GRANT_FIELDS = [
+  "policy_hash",
+  "manifest_sha256",
+  "shim_id",
+  "executor_id",
+  "adapter",
+  "adapter_version",
+  "nonce",
+] as const;
+
+const makeExecutionGrant = (overrides: Record<string, unknown> = {}) => {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    policy_hash: "policy-hash",
+    manifest_sha256: "sha256:manifest",
+    shim_id: "shim-1",
+    executor_id: "executor-1",
+    adapter: "structured-tool",
+    adapter_version: "2.1.0",
+    nonce: "nonce-test",
+    issued_at: now,
+    expires_at: now + 30,
+    ...overrides,
+  };
+};
+
+const MALFORMED_EXECUTION_GRANTS: Array<[string, unknown]> = [
+  ["non-object payload", "not-an-object"],
+  ...REQUIRED_EXECUTION_GRANT_FIELDS.flatMap(
+    (field): Array<[string, unknown]> => [
+      [`missing ${field}`, makeExecutionGrant({ [field]: undefined })],
+      [`empty ${field}`, makeExecutionGrant({ [field]: "" })],
+    ]
+  ),
+  ["non-integer issued_at", makeExecutionGrant({ issued_at: 1.5 })],
+  ["non-integer expires_at", makeExecutionGrant({ expires_at: 1.5 })],
+  [
+    "non-positive window",
+    makeExecutionGrant({ issued_at: 100, expires_at: 100 }),
+  ],
+  [
+    "window longer than 300 seconds",
+    makeExecutionGrant({ issued_at: 100, expires_at: 401 }),
+  ],
+  ["invalid repository_id", makeExecutionGrant({ repository_id: 42 })],
+  ["empty repository_id", makeExecutionGrant({ repository_id: "" })],
+];
+
 async function makeEdDSAKeypairAndJWKS() {
   const { privateKey, publicKey } = await generateKeyPair("EdDSA");
   const publicJwk = await exportJWK(publicKey);
@@ -111,6 +159,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
       policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite"],
       execution_grant: {
         policy_hash: "other-policy-hash",
         manifest_sha256: "sha256:manifest",
@@ -138,6 +187,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
       policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite"],
       execution_grant: {
         policy_hash: "policy-hash",
         manifest_sha256: "sha256:manifest",
@@ -167,6 +217,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
       policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite"],
       execution_grant: {
         policy_hash: "policy-hash",
         manifest_sha256: "sha256:manifest",
@@ -196,6 +247,7 @@ describe("verifyIntentAttestation", () => {
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
       policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite"],
       execution_grant: {
         policy_hash: "policy-hash",
         manifest_sha256: "sha256:manifest",
@@ -216,6 +268,73 @@ describe("verifyIntentAttestation", () => {
 
     await expect(verifyIntentAttestation(jwt, jwks)).resolves.toBeDefined();
   });
+
+  it.each([
+    ["missing policyHash", undefined],
+    ["non-string policyHash", 7],
+  ])("rejects %s", async (_label, policyHash) => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      ...(policyHash !== undefined && { policyHash }),
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+      "Payload missing or invalid policyHash"
+    );
+  });
+
+  it.each(MALFORMED_EXECUTION_GRANTS)(
+    "rejects execution grants with %s",
+    async (_label, executionGrant) => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+      capabilities: ["filesystem.overwrite"],
+      execution_grant: executionGrant,
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+      "execution_grant claim is malformed"
+    );
+    }
+  );
+
+  it.each([
+    ["missing capabilities", undefined],
+    ["empty capabilities", []],
+  ])(
+    "rejects an execution grant with %s",
+    async (_label, capabilities) => {
+      const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+        ...(capabilities !== undefined && { capabilities }),
+        execution_grant: makeExecutionGrant(),
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("1h")
+        .setIssuedAt()
+        .sign(privateKey);
+
+      await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+        "execution_grant requires at least one capability"
+      );
+    }
+  );
 
   it("rejects a token signed with HS256 (wrong algorithm)", async () => {
     const secret = new TextEncoder().encode("super-secret-key-that-is-long-enough");

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -22,6 +22,8 @@ const REQUIRED_EXECUTION_GRANT_FIELDS = [
   "adapter",
   "adapter_version",
   "nonce",
+  "issued_at",
+  "expires_at",
 ] as const;
 
 const makeExecutionGrant = (overrides: Record<string, unknown> = {}) => {
@@ -137,6 +139,47 @@ describe("verifyIntentAttestation", () => {
     expect(result.claims.capabilities).toEqual(["filesystem.overwrite", "git.push_fast_forward"]);
     expect(result.claims.execution_grant).toEqual(executionGrant);
   });
+
+  it.each(["rpc:write", "bundler:send"])(
+    "accepts the documented %s receipt scope",
+    async (scope) => {
+      const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+        scope,
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("1h")
+        .setIssuedAt()
+        .sign(privateKey);
+
+      const result = await verifyIntentAttestation(jwt, jwks);
+      expect(result.claims.scope).toBe(scope);
+    }
+  );
+
+  it.each(["admin", "", 4])(
+    "rejects the unsupported receipt scope %j",
+    async (scope) => {
+      const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+        scope,
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("1h")
+        .setIssuedAt()
+        .sign(privateKey);
+
+      await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+        "scope claim must be rpc:write or bundler:send"
+      );
+    }
+  );
 
   it("rejects malformed capability claims", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
@@ -289,25 +332,89 @@ describe("verifyIntentAttestation", () => {
     );
   });
 
-  it.each(MALFORMED_EXECUTION_GRANTS)(
-    "rejects execution grants with %s",
-    async (_label, executionGrant) => {
+  it("rejects a token without exp", async () => {
     const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
     const jwt = await new SignJWT({
       intent: VALID_INTENT,
       policyHash: "policy-hash",
-      capabilities: ["filesystem.overwrite"],
-      execution_grant: executionGrant,
     })
       .setProtectedHeader({ alg: "EdDSA" })
       .setIssuer("sigil-core")
-      .setExpirationTime("1h")
       .setIssuedAt()
       .sign(privateKey);
 
     await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
-      "execution_grant claim is malformed"
+      "Payload missing or invalid exp"
     );
+  });
+
+  it("rejects a token without iat", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+      "Payload missing or invalid iat"
+    );
+  });
+
+  it("rejects a token issued beyond the five-second clock tolerance", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt(Math.floor(Date.now() / 1000) + 6)
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+      "iat claim is beyond the five-second clock tolerance"
+    );
+  });
+
+  it("allows the documented five-second JWT issuance clock tolerance", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt(Math.floor(Date.now() / 1000) + 5)
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).resolves.toBeDefined();
+  });
+
+  it.each(MALFORMED_EXECUTION_GRANTS)(
+    "rejects execution grants with %s",
+    async (_label, executionGrant) => {
+      const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+      const jwt = await new SignJWT({
+        intent: VALID_INTENT,
+        policyHash: "policy-hash",
+        capabilities: ["filesystem.overwrite"],
+        execution_grant: executionGrant,
+      })
+        .setProtectedHeader({ alg: "EdDSA" })
+        .setIssuer("sigil-core")
+        .setExpirationTime("1h")
+        .setIssuedAt()
+        .sign(privateKey);
+
+      await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(
+        "execution_grant claim is malformed"
+      );
     }
   );
 

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -102,6 +102,32 @@ describe("verifyIntentAttestation", () => {
     await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(InvalidPayloadError);
   });
 
+  it("rejects an execution grant bound to a different policy hash", async () => {
+    const { privateKey, jwks } = await makeEdDSAKeypairAndJWKS();
+    const jwt = await new SignJWT({
+      intent: VALID_INTENT,
+      policyHash: "policy-hash",
+      execution_grant: {
+        policy_hash: "other-policy-hash",
+        manifest_sha256: "sha256:manifest",
+        shim_id: "shim-1",
+        executor_id: "executor-1",
+        adapter: "structured-tool",
+        adapter_version: "2.1.0",
+        nonce: "nonce-1",
+        issued_at: Math.floor(Date.now() / 1000),
+        expires_at: Math.floor(Date.now() / 1000) + 30,
+      },
+    })
+      .setProtectedHeader({ alg: "EdDSA" })
+      .setIssuer("sigil-core")
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(privateKey);
+
+    await expect(verifyIntentAttestation(jwt, jwks)).rejects.toThrow(InvalidPayloadError);
+  });
+
   it("rejects a token signed with HS256 (wrong algorithm)", async () => {
     const secret = new TextEncoder().encode("super-secret-key-that-is-long-enough");
 


### PR DESCRIPTION
## Summary
- add typed Policy 2.1 capability and execution-grant claims
- bind execution grants to the attested policy hash and enforce their short-lived validity window
- preserve the current hybrid PQC documentation from main

## Verification
- `npm run typecheck`
- `npm test` (12 tests)
- `npm run build`

<!-- sigil-review-fallback sha=7a783e1dc524ac702612a752cb419f23adf639d8 verdict=verified -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `execution_grant` and execution capability claims (`capabilities`) in intent attestation verification.
* **Bug Fixes**
  * Strengthened intent attestation validation for `policyHash`, tightened `iat/exp` timing rules with clock tolerance, enforced execution-grant window constraints, and added cross-checking between attestation and its grant.
* **Documentation**
  * Updated the intent-attestation overview and normative verification rules for `execution_grant` and capability requirements.
* **Tests**
  * Expanded test coverage for valid/invalid grants, hash mismatches, and tolerance/lifetime boundary cases.
* **Chores**
  * Re-exported the `ExecutionGrantClaim` type and updated the verified claims shape to require `iat`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->