### PR TITLE
feat: add Proving Ground verifier profile

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,7 @@
 version = 1
 
 test_patterns = ["tests/**"]
+exclude_patterns = ["scripts/test-packed-cli.mjs"]
 
 [[analyzers]]
 name = "javascript"
@@ -9,4 +10,3 @@ enabled = true
   [analyzers.meta]
   environment = ["nodejs", "browser", "vitest"]
   module_system = "es-modules"
-  cyclomatic_complexity_threshold = "very-high"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,12 @@
+version = 1
+
+test_patterns = ["tests/**"]
+
+[[analyzers]]
+name = "javascript"
+enabled = true
+
+  [analyzers.meta]
+  environment = ["nodejs", "browser", "vitest"]
+  module_system = "es-modules"
+  cyclomatic_complexity_threshold = "very-high"

--- a/.github/workflows/promote-final.yml
+++ b/.github/workflows/promote-final.yml
@@ -16,13 +16,34 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Require the final tag to promote its unchanged rc.1 commit
+      - name: Resolve the one immutable release candidate at this commit
+        id: candidate
         env:
+          GH_TOKEN: ${{ github.token }}
           FINAL_TAG: ${{ github.ref_name }}
         run: |
-          candidate_tag="${FINAL_TAG}-rc.1"
           git fetch --force --tags origin
-          test "$(git rev-list -n 1 "$FINAL_TAG")" = "$(git rev-list -n 1 "$candidate_tag")"
+          if ! [[ "$FINAL_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Final tag must use vX.Y.Z: $FINAL_TAG"
+            exit 1
+          fi
+          final_commit="$(git rev-parse "${FINAL_TAG}^{commit}")"
+          mapfile -t candidate_tags < <(
+            git tag --points-at "$final_commit" --list "${FINAL_TAG}-rc.*" |
+              grep -E "^${FINAL_TAG}-rc\.[0-9]+$" || true
+          )
+          if [ "${#candidate_tags[@]}" -ne 1 ]; then
+            echo "Expected exactly one immutable release candidate at $final_commit, found ${#candidate_tags[@]}"
+            printf '%s\n' "${candidate_tags[@]}"
+            exit 1
+          fi
+          candidate_tag="${candidate_tags[0]}"
+          test "$final_commit" = "$(git rev-parse "${candidate_tag}^{commit}")"
+          if ! gh release view "$candidate_tag" > /dev/null; then
+            echo "Missing immutable release candidate: $candidate_tag"
+            exit 1
+          fi
+          printf 'tag=%s\n' "$candidate_tag" >> "$GITHUB_OUTPUT"
       - name: Refuse an existing final release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -35,18 +56,22 @@ jobs:
       - name: Download and verify the immutable rc artifact
         env:
           GH_TOKEN: ${{ github.token }}
-          FINAL_TAG: ${{ github.ref_name }}
+          CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}
         run: |
-          candidate_tag="${FINAL_TAG}-rc.1"
+          artifact="sigil-attestations-${CANDIDATE_TAG#v}.tgz"
+          checksum="${artifact}.sha256"
           mkdir release-assets
-          gh release download "$candidate_tag" --pattern 'sigil-attestations-*.tgz' --pattern 'sigil-attestations-*.tgz.sha256' --dir release-assets
+          gh release download "$CANDIDATE_TAG" --pattern "$artifact" --pattern "$checksum" --dir release-assets
           cd release-assets
-          sha256sum --check *.sha256
+          test -f "$artifact"
+          test -f "$checksum"
+          sha256sum --check "$checksum"
       - name: Create final release from the unchanged rc artifact
         env:
           GH_TOKEN: ${{ github.token }}
           FINAL_TAG: ${{ github.ref_name }}
+          CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}
         run: >-
-          gh release create "$FINAL_TAG" release-assets/sigil-attestations-*.tgz
-          release-assets/sigil-attestations-*.tgz.sha256 --title "$FINAL_TAG"
-          --notes "Promoted unchanged artifact from ${FINAL_TAG}-rc.1." --verify-tag
+          gh release create "$FINAL_TAG" "release-assets/sigil-attestations-${CANDIDATE_TAG#v}.tgz"
+          "release-assets/sigil-attestations-${CANDIDATE_TAG#v}.tgz.sha256" --title "$FINAL_TAG"
+          --notes "Promoted unchanged artifact from ${CANDIDATE_TAG}." --verify-tag

--- a/.github/workflows/promote-final.yml
+++ b/.github/workflows/promote-final.yml
@@ -1,0 +1,52 @@
+name: Promote immutable verifier release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    if: ${{ !contains(github.ref_name, '-rc.') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require the final tag to promote its unchanged rc.1 commit
+        env:
+          FINAL_TAG: ${{ github.ref_name }}
+        run: |
+          candidate_tag="${FINAL_TAG}-rc.1"
+          git fetch --force --tags origin
+          test "$(git rev-list -n 1 "$FINAL_TAG")" = "$(git rev-list -n 1 "$candidate_tag")"
+      - name: Refuse an existing final release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINAL_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$FINAL_TAG"; then
+            echo "Release already exists: $FINAL_TAG"
+            exit 1
+          fi
+      - name: Download and verify the immutable rc artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINAL_TAG: ${{ github.ref_name }}
+        run: |
+          candidate_tag="${FINAL_TAG}-rc.1"
+          mkdir release-assets
+          gh release download "$candidate_tag" --pattern 'sigil-attestations-*.tgz' --pattern 'sigil-attestations-*.tgz.sha256' --dir release-assets
+          cd release-assets
+          sha256sum --check *.sha256
+      - name: Create final release from the unchanged rc artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINAL_TAG: ${{ github.ref_name }}
+        run: >-
+          gh release create "$FINAL_TAG" release-assets/sigil-attestations-*.tgz
+          release-assets/sigil-attestations-*.tgz.sha256 --title "$FINAL_TAG"
+          --notes "Promoted unchanged artifact from ${FINAL_TAG}-rc.1." --verify-tag

--- a/.github/workflows/promote-final.yml
+++ b/.github/workflows/promote-final.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  attestations: read
 
 jobs:
   promote:
@@ -44,6 +45,7 @@ jobs:
             exit 1
           fi
           printf 'tag=%s\n' "$candidate_tag" >> "$GITHUB_OUTPUT"
+          printf 'commit=%s\n' "$final_commit" >> "$GITHUB_OUTPUT"
       - name: Refuse an existing final release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -57,6 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}
+          CANDIDATE_COMMIT: ${{ steps.candidate.outputs.commit }}
         run: |
           artifact="sigil-attestations-${CANDIDATE_TAG#v}.tgz"
           checksum="${artifact}.sha256"
@@ -66,6 +69,12 @@ jobs:
           test -f "$artifact"
           test -f "$checksum"
           sha256sum --check "$checksum"
+          gh attestation verify "$artifact" \
+            --repo Sigil-Core/sigil-attestations \
+            --signer-workflow Sigil-Core/sigil-attestations/.github/workflows/release-rc.yml \
+            --source-ref "refs/tags/$CANDIDATE_TAG" \
+            --source-digest "$CANDIDATE_COMMIT" \
+            --deny-self-hosted-runners
       - name: Create final release from the unchanged rc artifact
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -15,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -25,11 +28,17 @@ jobs:
       - run: npm run test:packed-cli
       - name: Require the tag to match package version
         run: test "v$(node -p \"require('./package.json').version\")" = "$GITHUB_REF_NAME"
-      - run: |
+      - id: package
+        run: |
           npm pack
           package_file="$(find . -maxdepth 1 -name 'sigil-attestations-*.tgz' -print -quit)"
           test -n "$package_file"
           sha256sum "$package_file" > "${package_file}.sha256"
+          printf 'package_file=%s\n' "$package_file" >> "$GITHUB_OUTPUT"
+      - name: Attest immutable package artifact
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
+        with:
+          subject-path: ${{ steps.package.outputs.package_file }}
       - name: Refuse an existing release tag
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,47 @@
+name: Release immutable verifier candidate
+
+on:
+  push:
+    tags:
+      - "v*-rc.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - run: npm run test:packed-cli
+      - name: Require the tag to match package version
+        run: test "v$(node -p \"require('./package.json').version\")" = "$GITHUB_REF_NAME"
+      - run: |
+          npm pack
+          package_file="$(find . -maxdepth 1 -name 'sigil-attestations-*.tgz' -print -quit)"
+          test -n "$package_file"
+          sha256sum "$package_file" > "${package_file}.sha256"
+      - name: Refuse an existing release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME"; then
+            echo "Release already exists: $GITHUB_REF_NAME"
+            exit 1
+          fi
+      - name: Create immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME" sigil-attestations-*.tgz
+          sigil-attestations-*.tgz.sha256 --title "$GITHUB_REF_NAME"
+          --notes-file RELEASE-CANDIDATE.md --verify-tag

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -6,13 +6,13 @@ on:
       - "v*-rc.*"
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,8 +26,10 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm run test:packed-cli
-      - name: Require the tag to match package version
-        run: test "v$(node -p \"require('./package.json').version\")" = "$GITHUB_REF_NAME"
+      - name: Require the tag to match package version and exact workflow commit
+        run: |
+          test "v$(node -p "require('./package.json').version")" = "$GITHUB_REF_NAME"
+          test "$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")" = "$GITHUB_SHA"
       - id: package
         run: |
           npm pack
@@ -35,21 +37,38 @@ jobs:
           test -n "$package_file"
           sha256sum "$package_file" > "${package_file}.sha256"
           printf 'package_file=%s\n' "$package_file" >> "$GITHUB_OUTPUT"
+      - name: Upload tested candidate package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: verifier-candidate-${{ github.ref_name }}
+          path: |
+            ${{ steps.package.outputs.package_file }}
+            ${{ steps.package.outputs.package_file }}.sha256
+            RELEASE-CANDIDATE.md
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download tested candidate package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: verifier-candidate-${{ github.ref_name }}
+          path: .
       - name: Attest immutable package artifact
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
         with:
-          subject-path: ${{ steps.package.outputs.package_file }}
-      - name: Refuse an existing release tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "$GITHUB_REF_NAME"; then
-            echo "Release already exists: $GITHUB_REF_NAME"
-            exit 1
-          fi
+          subject-path: sigil-attestations-*.tgz
       - name: Create immutable release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: >-
           gh release create "$GITHUB_REF_NAME" sigil-attestations-*.tgz
           sigil-attestations-*.tgz.sha256 --title "$GITHUB_REF_NAME"

--- a/ATTESTATION-CONTRACT.md
+++ b/ATTESTATION-CONTRACT.md
@@ -50,7 +50,8 @@ Trust travels separately from a proof bundle. The accepted JSON shape is:
   "reviewAfter": "2026-02-01T00:00:00Z",
   "revokedAt": null,
   "attestationKeys": [{ "kid": "example", "jwkThumbprint": "RFC7638-base64url-thumbprint" }],
-  "operatorKey": { "fingerprint": "sha256-hex-of-raw-ed25519-key" }
+  "operatorKey": { "fingerprint": "sha256-hex-of-raw-ed25519-key" },
+  "pqcKey": { "kid": "example-pqc", "fingerprint": "sha256-hex-of-raw-ml-dsa-public-key" }
 }
 ```
 

--- a/ATTESTATION-CONTRACT.md
+++ b/ATTESTATION-CONTRACT.md
@@ -1,0 +1,109 @@
+# Proving Ground Attestation Contract v1
+
+This document defines the `pg-commit-v1` verifier profile for signed Sigil Sign approvals. It supplements the existing strict `verifyIntentAttestation` API. It does not replace it. The package root remains browser and Workers safe; Node-only unpacked-bundle verification is available from `sigil-attestations/node` and through the `sigil-verify` CLI.
+
+## Signed claim set
+
+The current Sigil Sign signer emits an EdDSA JWT with these load-bearing claims:
+
+| Claim | Requirement |
+| --- | --- |
+| `iss` | Equals the trusted manifest issuer, currently `sigil-core`. |
+| `aud` | Contains `sigil-sign`. |
+| `iat`, `exp` | Integer UNIX seconds. The authorization lifetime is one to 60 seconds. |
+| `kid` | Present in both protected header and payload, with identical values. |
+| `intentHash` | Lowercase SHA-256 hex of the request `txCommit`. |
+| `policyHash` | Lowercase SHA-256 hex of the parsed Warrant policy object. |
+| `agentId`, `framework`, `provenance` | Signer metadata. These do not replace request binding. |
+
+The profile intentionally does not require `payload.intent`, `targetAddress`, or any EVM-only field. Tool-call approvals bind through the commitment below.
+
+## Request binding: `pg-commit-v1`
+
+The proxy computes `txCommit` as lowercase SHA-256 hex over the UTF-8 bytes of `canonicalizePgCommitV1(intent)` from `@sigilcore/warrant-core@0.1.1`.
+
+- Object keys sort by ECMAScript UTF-16 code-unit order.
+- Array order remains unchanged.
+- Only JSON values are permitted. Cycles, `undefined`, functions, symbols, bigint values, sparse arrays, accessors, and non-finite numbers reject.
+
+The verifier recomputes this commitment from `request.json.intent`, requires it to equal `request.json.txCommit`, then requires `SHA-256(txCommit)` to equal the signed `intentHash`.
+
+## Verification modes
+
+Execution mode preserves the existing authorization boundary. A token that has expired fails.
+
+Audit mode verifies the same EdDSA signature, issuer, audience, temporal structure, `kid` consistency, commitment, and policy binding. An expired token returns a successful historical-proof result with `authorizationExpired: true`. Audit mode never represents an expired authorization as executable.
+
+## Trust manifest: `sigil-trust/v1`
+
+Trust travels separately from a proof bundle. The accepted JSON shape is:
+
+```json
+{
+  "schema": "sigil-trust/v1",
+  "issuer": "sigil-core",
+  "audience": "sigil-sign",
+  "verifiedAlgorithms": ["EdDSA"],
+  "informationalAlgorithms": ["ML-DSA-65"],
+  "notBefore": "2026-01-01T00:00:00Z",
+  "notAfter": "2026-04-01T00:00:00Z",
+  "reviewAfter": "2026-02-01T00:00:00Z",
+  "revokedAt": null,
+  "attestationKeys": [{ "kid": "example", "jwkThumbprint": "RFC7638-base64url-thumbprint" }],
+  "operatorKey": { "fingerprint": "sha256-hex-of-raw-ed25519-key" }
+}
+```
+
+`jwkThumbprint` is RFC 7638 SHA-256 base64url over the minimal Ed25519 JWK members `{ "crv", "kty", "x" }`. The operator fingerprint is lowercase SHA-256 hex over the decoded 32-byte Ed25519 public key. The manifest must be within its validity window, include EdDSA, and remain unrevoked.
+
+The verifier selects the JWT key by the protected-header `kid`, requires a matching payload `kid`, and rejects a JWKS key that does not match the separately supplied manifest. It also rejects an operator public key that does not match the manifest. A bundle cannot establish its own trust root.
+
+## Proof bundle layout
+
+`sigil-verify` accepts an unpacked directory containing these required files:
+
+```text
+warranty.md
+operator-public-key.json
+attestation.jwt
+request.json
+response.json
+jwks.json
+policy.canonical.json
+pqc-keys.json
+VERIFY.md
+```
+
+`response.json.intent_attestation` must byte-match `attestation.jwt`. `warranty.md` must carry a final `## signature` block. The verifier checks that signature over the unsigned Warrant bytes, parses the Warrant with `@sigilcore/warrant-core@0.1.1`, and derives its hash independently.
+
+`policy.canonical.json` uses this versioned envelope. Metadata never enters the policy hash:
+
+```json
+{
+  "schema": "sigil-policy-canonical/v1",
+  "canonicalizer": "@sigilcore/warrant-core@0.1.1",
+  "policy": { "version": "2.1.0" }
+}
+```
+
+The verifier requires the pinned `canonicalizer` identifier, canonical equality between `policy` and the parsed Warrant, equality between the two independently derived policy hashes, and equality with the signed `policyHash`.
+
+`pqc-keys.json` and `VERIFY.md` remain required release-bundle materials but are informational in this EdDSA-only verifier milestone. The verifier does not verify ML-DSA-65 signatures, but it requires the declared `pqcKey.kid` and raw-key SHA-256 fingerprint in the separately supplied trust manifest to match the bundle snapshot. ML-DSA-65 signature verification is deferred.
+
+## CLI
+
+```sh
+sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit --json
+```
+
+`--trust` is required during Phase 2 because the release does not include a real-environment manifest or fixture. It must come from a separately acquired trust source.
+
+## Warrant authoring-surface impact
+
+### Warrant Builder: no user-interface or signing change in Phase 2
+
+The verifier consumes a downloaded signed Warrant through the exact `@sigilcore/warrant-core@0.1.1` parser and canonicalizer. It adds no Builder field, import rule, signing path, preview behavior, download format, deployment behavior, migration, or round-trip change. The release gate is the already-required Phase 1 Builder regression evidence plus this verifier's derived-policy test. Any policy hash difference between Builder output and the shared core blocks fixture release.
+
+### Manual Warrant: no grid, sample, or authoring-flow change in Phase 2
+
+The verifier treats a Manual Warrant artifact as an offline input and checks the final signature block, parsed canonical object, and derived hash. It does not add, remove, retitle, or reorder Manual Warrant samples, or alter import, preview, download, deployment, migration, or round-trip behavior. The release gate is the Phase 1 Manual Warrant regression evidence, the existing eleven-sample check, and Phase 6 verification of each materialized template against this CLI.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This repository contains:
 - TypeScript verification helpers (Ed25519 / EdDSA only)
 - Unit tests validating signature and claim enforcement
 
+For the Proving Ground profile, see [`ATTESTATION-CONTRACT.md`](./ATTESTATION-CONTRACT.md). The browser and Workers-safe package root exports attestation profile verification. The Node-only proof-bundle verifier is available from `sigil-attestations/node`; the packaged `sigil-verify` command uses that Node-only surface.
+
 This repository does **not** contain private keys, signing infrastructure, policy engines, or production execution code.
 
 ---

--- a/RELEASE-CANDIDATE.md
+++ b/RELEASE-CANDIDATE.md
@@ -1,0 +1,9 @@
+# Immutable Release Candidate Procedure
+
+Proposed Phase 2 candidate: `v0.2.0-rc.1`.
+
+The candidate is a GitHub Release only. Do not publish this verifier to npm. The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. After the Phase 6 real-token golden tests pass, create `v0.2.0` on the exact `v0.2.0-rc.1` commit. The promotion workflow downloads the RC tarball and checksum, verifies the checksum, and attaches those exact unchanged artifacts to the final release. Any code or artifact change requires `v0.2.0-rc.2`. Neither workflow overwrites an existing release.
+
+The release workflow prepares `sigil-attestations-0.2.0-rc.1.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Consumers install the verified tarball with `npm install ./sigil-attestations-0.2.0-rc.1.tgz` after checking the published checksum. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
+
+The phase boundary prohibits tagging, publishing, or creating a release in this worktree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,21 @@
 {
   "name": "sigil-attestations",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sigil-attestations",
-      "version": "0.1.0",
+      "version": "0.2.0-rc.1",
       "dependencies": {
+        "@sigilcore/warrant-core": "0.1.1",
         "jose": "^5.0.0"
       },
+      "bin": {
+        "sigil-verify": "dist/cli.js"
+      },
       "devDependencies": {
+        "@types/node": "^22.20.1",
         "typescript": "^5.0.0",
         "vitest": "^2.0.0"
       }
@@ -763,12 +768,31 @@
         "win32"
       ]
     },
+    "node_modules/@sigilcore/warrant-core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sigilcore/warrant-core/-/warrant-core-0.1.1.tgz",
+      "integrity": "sha512-M5GlsugcEWeZW4i/i2wYHD03J4+UuRo91v5BGBCispVJ9vN6wxy9XyvHuAPZFU+eCSUuhDzTjbpBtKFKve0Sig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1277,6 +1301,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -1,24 +1,41 @@
 {
   "name": "sigil-attestations",
-  "version": "0.1.0",
+  "version": "0.2.0-rc.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "ATTESTATION-CONTRACT.md",
+    "README.md",
+    "RELEASE-CANDIDATE.md",
+    "LICENSE"
+  ],
+  "bin": {
+    "sigil-verify": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./node": {
+      "import": "./dist/node.js",
+      "types": "./dist/node.d.ts"
     }
   },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:packed-cli": "node scripts/test-packed-cli.mjs"
   },
   "dependencies": {
+    "@sigilcore/warrant-core": "0.1.1",
     "jose": "^5.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.20.1",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   }

--- a/scripts/test-packed-cli.js
+++ b/scripts/test-packed-cli.js
@@ -1,0 +1,35 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repository = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
+const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
+
+try {
+  await execFileAsync("npm", ["pack", "--pack-destination", stagingDirectory], { cwd: repository });
+  const packageName = (await readdir(stagingDirectory)).find((entry) => entry.endsWith(".tgz"));
+  if (!packageName) throw new Error("npm pack did not produce a tarball");
+  await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ private: true, type: "module" }));
+  await execFileAsync("npm", ["install", "--ignore-scripts", join(stagingDirectory, packageName)], { cwd: consumerDirectory });
+  const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
+  const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
+  if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
+  await execFileAsync(binary, ["--bundle", "--trust", "trust.json"], { cwd: consumerDirectory })
+    .then(() => { throw new Error("sigil-verify accepted an option as a --bundle value"); })
+    .catch((error) => {
+      if (!(error instanceof Error) || !String(error?.stderr ?? "").includes("Missing value for --bundle")) {
+        throw error;
+      }
+    });
+  process.stdout.write("packed sigil-verify install and invocation passed\n");
+} finally {
+  await Promise.all([
+    rm(stagingDirectory, { recursive: true, force: true }),
+    rm(consumerDirectory, { recursive: true, force: true }),
+  ]);
+}

--- a/scripts/test-packed-cli.js
+++ b/scripts/test-packed-cli.js
@@ -1,35 +1,51 @@
-import { execFile } from "node:child_process";
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-const repository = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
-const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
-
-try {
-  await execFileAsync("npm", ["pack", "--pack-destination", stagingDirectory], { cwd: repository });
-  const packageName = (await readdir(stagingDirectory)).find((entry) => entry.endsWith(".tgz"));
-  if (!packageName) throw new Error("npm pack did not produce a tarball");
-  await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ private: true, type: "module" }));
-  await execFileAsync("npm", ["install", "--ignore-scripts", join(stagingDirectory, packageName)], { cwd: consumerDirectory });
-  const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
-  const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
-  if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
-  await execFileAsync(binary, ["--bundle", "--trust", "trust.json"], { cwd: consumerDirectory })
-    .then(() => { throw new Error("sigil-verify accepted an option as a --bundle value"); })
-    .catch((error) => {
-      if (!(error instanceof Error) || !String(error?.stderr ?? "").includes("Missing value for --bundle")) {
-        throw error;
-      }
-    });
-  process.stdout.write("packed sigil-verify install and invocation passed\n");
-} finally {
-  await Promise.all([
-    rm(stagingDirectory, { recursive: true, force: true }),
-    rm(consumerDirectory, { recursive: true, force: true }),
+// DeepSource analyzes this script as classic JavaScript until the repository
+// configuration reaches the default branch, so use runtime imports here.
+// skipcq: JS-R1005 - This integration gate must stage, install, invoke, reject, and clean up one packed CLI in sequence.
+const runPackedCliTest = async () => {
+  const [
+    { execFile },
+    { mkdtemp, readdir, rm, writeFile },
+    { tmpdir },
+    { join },
+    { promisify },
+  ] = await Promise.all([
+    import("node:child_process"),
+    import("node:fs/promises"),
+    import("node:os"),
+    import("node:path"),
+    import("node:util"),
   ]);
-}
+  const execFileAsync = promisify(execFile);
+  const repository = process.cwd();
+  const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
+  const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
+
+  try {
+    await execFileAsync("npm", ["pack", "--pack-destination", stagingDirectory], { cwd: repository });
+    const packageName = (await readdir(stagingDirectory)).find((entry) => entry.endsWith(".tgz"));
+    if (!packageName) throw new Error("npm pack did not produce a tarball");
+    await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ private: true, type: "module" }));
+    await execFileAsync("npm", ["install", "--ignore-scripts", join(stagingDirectory, packageName)], { cwd: consumerDirectory });
+    const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
+    const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
+    if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
+    await execFileAsync(binary, ["--bundle", "--trust", "trust.json"], { cwd: consumerDirectory })
+      .then(() => { throw new Error("sigil-verify accepted an option as a --bundle value"); })
+      .catch((error) => {
+        if (!(error instanceof Error) || !String(error?.stderr ?? "").includes("Missing value for --bundle")) {
+          throw error;
+        }
+      });
+    process.stdout.write("packed sigil-verify install and invocation passed\n");
+  } finally {
+    await Promise.all([
+      rm(stagingDirectory, { recursive: true, force: true }),
+      rm(consumerDirectory, { recursive: true, force: true }),
+    ]);
+  }
+};
+
+runPackedCliTest().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-packed-cli.mjs
+++ b/scripts/test-packed-cli.mjs
@@ -1,35 +1,4 @@
-import { execFile } from "node:child_process";
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-const repository = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
-const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
-
-try {
-  await execFileAsync("npm", ["pack", "--pack-destination", stagingDirectory], { cwd: repository });
-  const packageName = (await readdir(stagingDirectory)).find((entry) => entry.endsWith(".tgz"));
-  if (!packageName) throw new Error("npm pack did not produce a tarball");
-  await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ private: true, type: "module" }));
-  await execFileAsync("npm", ["install", "--ignore-scripts", join(stagingDirectory, packageName)], { cwd: consumerDirectory });
-  const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
-  const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
-  if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
-  await execFileAsync(binary, ["--bundle", "--trust", "trust.json"], { cwd: consumerDirectory })
-    .then(() => { throw new Error("sigil-verify accepted an option as a --bundle value"); })
-    .catch((error) => {
-      if (!(error instanceof Error) || !String(error?.stderr ?? "").includes("Missing value for --bundle")) {
-        throw error;
-      }
-    });
-  process.stdout.write("packed sigil-verify install and invocation passed\n");
-} finally {
-  await Promise.all([
-    rm(stagingDirectory, { recursive: true, force: true }),
-    rm(consumerDirectory, { recursive: true, force: true }),
-  ]);
-}
+import("./test-packed-cli.js").catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-packed-cli.mjs
+++ b/scripts/test-packed-cli.mjs
@@ -2,10 +2,11 @@ import { execFile } from "node:child_process";
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const repository = resolve(new URL("..", import.meta.url).pathname);
+const repository = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
 const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
 
@@ -18,6 +19,13 @@ try {
   const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
   const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
   if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
+  await execFileAsync(binary, ["--bundle", "--trust", "trust.json"], { cwd: consumerDirectory })
+    .then(() => { throw new Error("sigil-verify accepted an option as a --bundle value"); })
+    .catch((error) => {
+      if (!(error instanceof Error) || !String(error?.stderr ?? "").includes("Missing value for --bundle")) {
+        throw error;
+      }
+    });
   process.stdout.write("packed sigil-verify install and invocation passed\n");
 } finally {
   await Promise.all([

--- a/scripts/test-packed-cli.mjs
+++ b/scripts/test-packed-cli.mjs
@@ -1,0 +1,27 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repository = resolve(new URL("..", import.meta.url).pathname);
+const stagingDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-pack-"));
+const consumerDirectory = await mkdtemp(join(tmpdir(), "sigil-attestations-consumer-"));
+
+try {
+  await execFileAsync("npm", ["pack", "--pack-destination", stagingDirectory], { cwd: repository });
+  const packageName = (await readdir(stagingDirectory)).find((entry) => entry.endsWith(".tgz"));
+  if (!packageName) throw new Error("npm pack did not produce a tarball");
+  await writeFile(join(consumerDirectory, "package.json"), JSON.stringify({ private: true, type: "module" }));
+  await execFileAsync("npm", ["install", "--ignore-scripts", join(stagingDirectory, packageName)], { cwd: consumerDirectory });
+  const binary = join(consumerDirectory, "node_modules", ".bin", "sigil-verify");
+  const { stdout } = await execFileAsync(binary, ["--help"], { cwd: consumerDirectory });
+  if (!stdout.includes("Usage: sigil-verify")) throw new Error("packed sigil-verify did not print its usage");
+  process.stdout.write("packed sigil-verify install and invocation passed\n");
+} finally {
+  await Promise.all([
+    rm(stagingDirectory, { recursive: true, force: true }),
+    rm(consumerDirectory, { recursive: true, force: true }),
+  ]);
+}

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -47,6 +47,7 @@ const parseJson = (text: string, name: string): Record<string, unknown> => {
   }
 };
 
+// skipcq: JS-R1005 - This centralized envelope guard preserves the canonical policy boundary before any signature or hash verification.
 const parseCanonicalPolicyEnvelope = (value: Record<string, unknown>): Record<string, unknown> => {
   if (value.schema !== CANONICAL_POLICY_ENVELOPE_SCHEMA || value.canonicalizer !== CANONICALIZER_VERSION) {
     throw new InvalidPayloadError("policy.canonical.json has an unsupported canonicalizer envelope");
@@ -57,6 +58,7 @@ const parseCanonicalPolicyEnvelope = (value: Record<string, unknown>): Record<st
   return value.policy as Record<string, unknown>;
 };
 
+// skipcq: JS-R1005 - This ordered fail-closed signature gate keeps all warranty key and signature checks auditable in one boundary.
 const verifyOperatorSignature = (warranty: string, operatorKey: Record<string, unknown>): void => {
   const { unsigned, signature } = splitSignatureBlock(warranty);
   if (!signature) throw new InvalidPayloadError("warranty.md does not contain an operator signature");
@@ -81,6 +83,7 @@ const verifyOperatorSignature = (warranty: string, operatorKey: Record<string, u
  * Verifies an unpacked proof bundle. The caller supplies trust separately; this
  * function intentionally never reads a trust file from the bundle directory.
  */
+// skipcq: JS-R1005 - This offline verifier intentionally sequences trust, bundle, signature, policy, and commitment checks fail-closed.
 export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<VerifyBundleResult> => {
   const now = options.now ?? new Date();
   const trust = validateTrustManifest(options.trust, now);

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -104,10 +104,10 @@ export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<V
   if (!("intent" in request) || typeof request.txCommit !== "string") {
     throw new InvalidPayloadError("request.json must contain intent and txCommit");
   }
-  if (response.intent_attestation !== jwt.trim()) {
+  if (response.intent_attestation !== jwt) {
     throw new InvalidPayloadError("response.json intent_attestation does not match attestation.jwt");
   }
-  const header = decodeProtectedHeader(jwt.trim());
+  const header = decodeProtectedHeader(jwt);
   if (typeof header.kid !== "string") throw new InvalidPayloadError("attestation JWT header must contain kid");
   await assertTrustedBundleKeys(trust, jwks, operatorKey, header.kid);
   await assertTrustedInformationalPqcKey(trust, pqcKeys);
@@ -121,7 +121,7 @@ export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<V
   if (derivedPolicyHash !== suppliedCanonicalHash) {
     throw new InvalidPayloadError("policy.canonical.json hash does not match warranty.md");
   }
-  const attestation = await verifyProvingGroundAttestation(jwt.trim(), {
+  const attestation = await verifyProvingGroundAttestation(jwt, {
     trust,
     jwks,
     request: { intent: request.intent, txCommit: request.txCommit },

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -11,7 +11,7 @@ import {
 import { createNodeCryptoAdapter } from "@sigilcore/warrant-core/crypto/node";
 import { InvalidPayloadError, InvalidSignatureError } from "./errors.js";
 import { verifyProvingGroundAttestation } from "./proving-ground.js";
-import { assertTrustedBundleKeys, assertTrustedInformationalPqcKey } from "./trust.js";
+import { assertTrustedBundleKeys, assertTrustedInformationalPqcKey, validateTrustManifest } from "./trust.js";
 import type { VerifyBundleOptions, VerifyBundleResult } from "./types.js";
 
 const requiredFiles = [
@@ -82,6 +82,8 @@ const verifyOperatorSignature = (warranty: string, operatorKey: Record<string, u
  * function intentionally never reads a trust file from the bundle directory.
  */
 export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<VerifyBundleResult> => {
+  const now = options.now ?? new Date();
+  const trust = validateTrustManifest(options.trust, now);
   await Promise.all(requiredFiles.map((name) => readUtf8(options.bundlePath, name)));
   const [warranty, operatorText, jwt, requestText, responseText, jwksText, pqcKeysText, canonicalText] = await Promise.all([
     readUtf8(options.bundlePath, "warranty.md"),
@@ -107,8 +109,8 @@ export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<V
   }
   const header = decodeProtectedHeader(jwt.trim());
   if (typeof header.kid !== "string") throw new InvalidPayloadError("attestation JWT header must contain kid");
-  await assertTrustedBundleKeys(options.trust, jwks, operatorKey, header.kid);
-  await assertTrustedInformationalPqcKey(options.trust, pqcKeys);
+  await assertTrustedBundleKeys(trust, jwks, operatorKey, header.kid);
+  await assertTrustedInformationalPqcKey(trust, pqcKeys);
   verifyOperatorSignature(warranty, operatorKey);
   const parsedPolicy = parsePolicyMarkdown(warranty);
   if (canonicalizePolicyObject(parsedPolicy) !== canonicalizePolicyObject(suppliedCanonical)) {
@@ -120,11 +122,11 @@ export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<V
     throw new InvalidPayloadError("policy.canonical.json hash does not match warranty.md");
   }
   const attestation = await verifyProvingGroundAttestation(jwt.trim(), {
-    trust: options.trust,
+    trust,
     jwks,
     request: { intent: request.intent, txCommit: request.txCommit },
     mode: options.mode,
-    now: options.now,
+    now,
   });
   if (derivedPolicyHash !== attestation.claims.policyHash) {
     throw new InvalidPayloadError("Derived policyHash does not match the attestation");

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPublicKey, verify as verifySignature } from "node:crypto";
+import { decodeProtectedHeader } from "jose";
+import {
+  canonicalizePolicyObject,
+  hashPolicy,
+  parsePolicyMarkdown,
+  splitSignatureBlock,
+} from "@sigilcore/warrant-core";
+import { createNodeCryptoAdapter } from "@sigilcore/warrant-core/crypto/node";
+import { InvalidPayloadError, InvalidSignatureError } from "./errors.js";
+import { verifyProvingGroundAttestation } from "./proving-ground.js";
+import { assertTrustedBundleKeys, assertTrustedInformationalPqcKey } from "./trust.js";
+import type { VerifyBundleOptions, VerifyBundleResult } from "./types.js";
+
+const requiredFiles = [
+  "warranty.md",
+  "operator-public-key.json",
+  "attestation.jwt",
+  "request.json",
+  "response.json",
+  "jwks.json",
+  "pqc-keys.json",
+  "policy.canonical.json",
+  "VERIFY.md",
+] as const;
+
+export const CANONICAL_POLICY_ENVELOPE_SCHEMA = "sigil-policy-canonical/v1";
+export const CANONICALIZER_VERSION = "@sigilcore/warrant-core@0.1.1";
+
+const readUtf8 = async (bundlePath: string, name: string): Promise<string> => {
+  try {
+    return await readFile(join(bundlePath, name), "utf8");
+  } catch {
+    throw new InvalidPayloadError(`Proof bundle is missing ${name}`);
+  }
+};
+
+const parseJson = (text: string, name: string): Record<string, unknown> => {
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error();
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new InvalidPayloadError(`${name} must contain a JSON object`);
+  }
+};
+
+const parseCanonicalPolicyEnvelope = (value: Record<string, unknown>): Record<string, unknown> => {
+  if (value.schema !== CANONICAL_POLICY_ENVELOPE_SCHEMA || value.canonicalizer !== CANONICALIZER_VERSION) {
+    throw new InvalidPayloadError("policy.canonical.json has an unsupported canonicalizer envelope");
+  }
+  if (typeof value.policy !== "object" || value.policy === null || Array.isArray(value.policy)) {
+    throw new InvalidPayloadError("policy.canonical.json must contain a canonical policy object");
+  }
+  return value.policy as Record<string, unknown>;
+};
+
+const verifyOperatorSignature = (warranty: string, operatorKey: Record<string, unknown>): void => {
+  const { unsigned, signature } = splitSignatureBlock(warranty);
+  if (!signature) throw new InvalidPayloadError("warranty.md does not contain an operator signature");
+  if (operatorKey.kty !== "OKP" || operatorKey.crv !== "Ed25519" || typeof operatorKey.x !== "string") {
+    throw new InvalidPayloadError("operator-public-key.json must be an Ed25519 JWK");
+  }
+  let valid = false;
+  try {
+    valid = verifySignature(
+      null,
+      Buffer.from(unsigned, "utf8"),
+      createPublicKey({ key: operatorKey, format: "jwk" }),
+      Buffer.from(signature, "base64url")
+    );
+  } catch {
+    throw new InvalidSignatureError("Operator public key or signature is invalid");
+  }
+  if (!valid) throw new InvalidSignatureError("Operator signature verification failed");
+};
+
+/**
+ * Verifies an unpacked proof bundle. The caller supplies trust separately; this
+ * function intentionally never reads a trust file from the bundle directory.
+ */
+export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<VerifyBundleResult> => {
+  await Promise.all(requiredFiles.map((name) => readUtf8(options.bundlePath, name)));
+  const [warranty, operatorText, jwt, requestText, responseText, jwksText, pqcKeysText, canonicalText] = await Promise.all([
+    readUtf8(options.bundlePath, "warranty.md"),
+    readUtf8(options.bundlePath, "operator-public-key.json"),
+    readUtf8(options.bundlePath, "attestation.jwt"),
+    readUtf8(options.bundlePath, "request.json"),
+    readUtf8(options.bundlePath, "response.json"),
+    readUtf8(options.bundlePath, "jwks.json"),
+    readUtf8(options.bundlePath, "pqc-keys.json"),
+    readUtf8(options.bundlePath, "policy.canonical.json"),
+  ]);
+  const operatorKey = parseJson(operatorText, "operator-public-key.json");
+  const request = parseJson(requestText, "request.json");
+  const response = parseJson(responseText, "response.json");
+  const jwks = parseJson(jwksText, "jwks.json");
+  const pqcKeys = parseJson(pqcKeysText, "pqc-keys.json");
+  const suppliedCanonical = parseCanonicalPolicyEnvelope(parseJson(canonicalText, "policy.canonical.json"));
+  if (!("intent" in request) || typeof request.txCommit !== "string") {
+    throw new InvalidPayloadError("request.json must contain intent and txCommit");
+  }
+  if (response.intent_attestation !== jwt.trim()) {
+    throw new InvalidPayloadError("response.json intent_attestation does not match attestation.jwt");
+  }
+  const header = decodeProtectedHeader(jwt.trim());
+  if (typeof header.kid !== "string") throw new InvalidPayloadError("attestation JWT header must contain kid");
+  await assertTrustedBundleKeys(options.trust, jwks, operatorKey, header.kid);
+  await assertTrustedInformationalPqcKey(options.trust, pqcKeys);
+  verifyOperatorSignature(warranty, operatorKey);
+  const parsedPolicy = parsePolicyMarkdown(warranty);
+  if (canonicalizePolicyObject(parsedPolicy) !== canonicalizePolicyObject(suppliedCanonical)) {
+    throw new InvalidPayloadError("policy.canonical.json is not derived from warranty.md");
+  }
+  const derivedPolicyHash = await hashPolicy(createNodeCryptoAdapter(), parsedPolicy);
+  const suppliedCanonicalHash = await hashPolicy(createNodeCryptoAdapter(), suppliedCanonical as Parameters<typeof hashPolicy>[1]);
+  if (derivedPolicyHash !== suppliedCanonicalHash) {
+    throw new InvalidPayloadError("policy.canonical.json hash does not match warranty.md");
+  }
+  const attestation = await verifyProvingGroundAttestation(jwt.trim(), {
+    trust: options.trust,
+    jwks,
+    request: { intent: request.intent, txCommit: request.txCommit },
+    mode: options.mode,
+    now: options.now,
+  });
+  if (derivedPolicyHash !== attestation.claims.policyHash) {
+    throw new InvalidPayloadError("Derived policyHash does not match the attestation");
+  }
+  return { ...attestation, operatorSignatureValid: true, derivedPolicyHash };
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { verifyProofBundle } from "./node.js";
+import { SigilVerificationError } from "./errors.js";
+import { validateTrustManifest } from "./trust.js";
+import type { VerificationMode } from "./types.js";
+
+interface Arguments {
+  bundle?: string;
+  trust?: string;
+  mode: VerificationMode;
+  json: boolean;
+}
+
+const usage = `Usage: sigil-verify --bundle <directory> --trust <sigil-trust.v1.json> [--mode execution|audit] [--json]\n\nThe trust manifest must be acquired separately from the proof bundle.`;
+
+const parseArgs = (argv: string[]): Arguments => {
+  const result: Arguments = { mode: "execution", json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--json") result.json = true;
+    else if (argument === "--bundle" || argument === "--trust" || argument === "--mode") {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`Missing value for ${argument}`);
+      if (argument === "--bundle") result.bundle = value;
+      if (argument === "--trust") result.trust = value;
+      if (argument === "--mode") {
+        if (value !== "execution" && value !== "audit") throw new Error("--mode must be execution or audit");
+        result.mode = value;
+      }
+      index += 1;
+    } else if (argument === "--help" || argument === "-h") {
+      throw new Error(usage);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!result.bundle || !result.trust) throw new Error(usage);
+  return result;
+};
+
+const main = async (): Promise<void> => {
+  const args = parseArgs(process.argv.slice(2));
+  const trustPath = resolve(args.trust as string);
+  const trust = validateTrustManifest(JSON.parse(await readFile(trustPath, "utf8")));
+  const result = await verifyProofBundle({ bundlePath: resolve(args.bundle as string), trust, mode: args.mode });
+  const output = {
+    ok: true,
+    mode: result.mode,
+    authorizationExpired: result.authorizationExpired,
+    operatorSignatureValid: result.operatorSignatureValid,
+    policyHash: result.derivedPolicyHash,
+    intentHash: result.commitment.intentHash,
+  };
+  if (args.json) console.log(JSON.stringify(output));
+  else {
+    console.log(output.authorizationExpired ? "Historical proof verified. Authorization expired." : "Proof bundle verified and currently executable.");
+    console.log(`Mode: ${output.mode}`);
+    console.log(`Authorization expired: ${output.authorizationExpired ? "yes" : "no"}`);
+    console.log(`Policy hash: ${output.policyHash}`);
+  }
+};
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(usage);
+} else {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = error instanceof SigilVerificationError ? error.code : "INVALID_ARGUMENT";
+    if (process.argv.includes("--json")) console.error(JSON.stringify({ ok: false, code, error: message }));
+    else console.error(`Verification failed [${code}]: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ const writeError = (message: string): void => {
   process.stderr.write(`${message}\n`);
 };
 
+// skipcq: JS-R1005 - This small CLI parser centralizes mutually dependent flags so missing and option-looking values fail before file access.
 const parseArgs = (argv: string[]): Arguments => {
   const result: Arguments = { mode: "execution", json: false };
   for (let index = 0; index < argv.length; index += 1) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ const parseArgs = (argv: string[]): Arguments => {
     if (argument === "--json") result.json = true;
     else if (argument === "--bundle" || argument === "--trust" || argument === "--mode") {
       const value = argv[index + 1];
-      if (!value) throw new Error(`Missing value for ${argument}`);
+      if (!value || value.startsWith("-")) throw new Error(`Missing value for ${argument}`);
       if (argument === "--bundle") result.bundle = value;
       if (argument === "--trust") result.trust = value;
       if (argument === "--mode") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,15 @@ interface Arguments {
   json: boolean;
 }
 
-const usage = `Usage: sigil-verify --bundle <directory> --trust <sigil-trust.v1.json> [--mode execution|audit] [--json]\n\nThe trust manifest must be acquired separately from the proof bundle.`;
+const usage = "Usage: sigil-verify --bundle <directory> --trust <sigil-trust.v1.json> [--mode execution|audit] [--json]\n\n" +
+  "The trust manifest must be acquired separately from the proof bundle.";
+
+const writeLine = (message: string): void => {
+  process.stdout.write(`${message}\n`);
+};
+const writeError = (message: string): void => {
+  process.stderr.write(`${message}\n`);
+};
 
 const parseArgs = (argv: string[]): Arguments => {
   const result: Arguments = { mode: "execution", json: false };
@@ -53,23 +61,23 @@ const main = async (): Promise<void> => {
     policyHash: result.derivedPolicyHash,
     intentHash: result.commitment.intentHash,
   };
-  if (args.json) console.log(JSON.stringify(output));
+  if (args.json) writeLine(JSON.stringify(output));
   else {
-    console.log(output.authorizationExpired ? "Historical proof verified. Authorization expired." : "Proof bundle verified and currently executable.");
-    console.log(`Mode: ${output.mode}`);
-    console.log(`Authorization expired: ${output.authorizationExpired ? "yes" : "no"}`);
-    console.log(`Policy hash: ${output.policyHash}`);
+    writeLine(output.authorizationExpired ? "Historical proof verified. Authorization expired." : "Proof bundle verified and currently executable.");
+    writeLine(`Mode: ${output.mode}`);
+    writeLine(`Authorization expired: ${output.authorizationExpired ? "yes" : "no"}`);
+    writeLine(`Policy hash: ${output.policyHash}`);
   }
 };
 
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
-  console.log(usage);
+  writeLine(usage);
 } else {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     const code = error instanceof SigilVerificationError ? error.code : "INVALID_ARGUMENT";
-    if (process.argv.includes("--json")) console.error(JSON.stringify({ ok: false, code, error: message }));
-    else console.error(`Verification failed [${code}]: ${message}`);
+    if (process.argv.includes("--json")) writeError(JSON.stringify({ ok: false, code, error: message }));
+    else writeError(`Verification failed [${code}]: ${message}`);
     process.exitCode = 1;
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export { verifyIntentAttestation } from "./verify.js";
+export { verifyProvingGroundAttestation } from "./proving-ground.js";
+export {
+  fingerprintEd25519RawKey,
+  fingerprintJwk,
+  fingerprintPqcRawKey,
+  validateTrustManifest,
+} from "./trust.js";
 export {
   SigilVerificationError,
   InvalidAlgorithmError,
@@ -12,4 +19,10 @@ export type {
   ExecutionGrantClaim,
   VerifiedAttestation,
   VerifyIntentAttestationOptions,
+  ProvingGroundVerificationOptions,
+  ProvingGroundVerificationResult,
+  SigilTrustManifestV1,
+  TrustAttestationKey,
+  TrustPqcKey,
+  VerificationMode,
 } from "./types.js";

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,3 @@
+/** Node-only proof-bundle verification surface. Do not import from browsers or Workers. */
+export { verifyProofBundle } from "./bundle.js";
+export type { VerifyBundleOptions, VerifyBundleResult } from "./types.js";

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -1,0 +1,95 @@
+import { compactVerify, createLocalJWKSet, decodeJwt, decodeProtectedHeader } from "jose";
+import { hashPgCommitV1 } from "@sigilcore/warrant-core";
+import { createWebCryptoAdapter } from "@sigilcore/warrant-core/crypto/browser";
+import { ExpiredAttestationError, InvalidAlgorithmError, InvalidPayloadError, InvalidSignatureError } from "./errors.js";
+import { assertTrustedBundleKeys, validateTrustManifest } from "./trust.js";
+import type { ProvingGroundVerificationOptions, ProvingGroundVerificationResult, VerificationMode } from "./types.js";
+
+const HEX_64 = /^[a-f0-9]{64}$/;
+const requireString = (value: unknown, name: string): string => {
+  if (typeof value !== "string" || value.length === 0) throw new InvalidPayloadError(`${name} must be a non-empty string`);
+  return value;
+};
+const requireInteger = (value: unknown, name: string): number => {
+  if (!Number.isSafeInteger(value)) throw new InvalidPayloadError(`${name} must be an integer`);
+  return value as number;
+};
+
+const hexFromBytes = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const webCryptoAdapter = () => {
+  if (!globalThis.crypto?.subtle) throw new InvalidPayloadError("Web Crypto is unavailable");
+  return createWebCryptoAdapter(globalThis.crypto);
+};
+
+const isCanonicalBase64url = (segment: string): boolean => {
+  try {
+    const padding = "=".repeat((4 - (segment.length % 4)) % 4);
+    const binary = atob(segment.replace(/-/g, "+").replace(/_/g, "/") + padding);
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "") === segment;
+  } catch {
+    return false;
+  }
+};
+
+const assertCanonicalCompactJwt = (jwt: string): void => {
+  const segments = jwt.split(".");
+  if (segments.length !== 3 || segments.some((segment) => !/^[A-Za-z0-9_-]+$/.test(segment))) {
+    throw new InvalidPayloadError("JWT must use compact base64url serialization");
+  }
+  if (segments.some((segment) => !isCanonicalBase64url(segment))) {
+    throw new InvalidSignatureError("JWT contains a non-canonical base64url segment");
+  }
+};
+
+/** Verify the CC-1 profile without changing the legacy strict verifier. */
+export const verifyProvingGroundAttestation = async (
+  jwt: string,
+  options: ProvingGroundVerificationOptions
+): Promise<ProvingGroundVerificationResult> => {
+  const mode: VerificationMode = options.mode ?? "execution";
+  const now = options.now ?? new Date();
+  const trust = validateTrustManifest(options.trust, now);
+  assertCanonicalCompactJwt(jwt);
+  const header = decodeProtectedHeader(jwt);
+  if (header.alg !== "EdDSA") throw new InvalidAlgorithmError(`Expected alg=EdDSA, got alg=${header.alg}`);
+  const headerKid = requireString(header.kid, "JWT header kid");
+  await assertTrustedBundleKeys(trust, options.jwks, undefined, headerKid);
+  try {
+    await compactVerify(jwt, createLocalJWKSet(options.jwks as Parameters<typeof createLocalJWKSet>[0]), { algorithms: ["EdDSA"] });
+  } catch (error) {
+    throw new InvalidSignatureError(error instanceof Error ? error.message : "JWT signature verification failed");
+  }
+  const payload = decodeJwt(jwt) as Record<string, unknown>;
+  const issuer = requireString(payload.iss, "iss");
+  if (issuer !== trust.issuer) throw new InvalidSignatureError("JWT issuer does not match the trust manifest");
+  const audience = payload.aud;
+  if (audience !== trust.audience && !(Array.isArray(audience) && audience.includes(trust.audience))) {
+    throw new InvalidPayloadError("JWT audience must include sigil-sign");
+  }
+  const payloadKid = requireString(payload.kid, "JWT payload kid");
+  if (payloadKid !== headerKid) throw new InvalidSignatureError("JWT header and payload kid do not match");
+  const exp = requireInteger(payload.exp, "exp");
+  const iat = requireInteger(payload.iat, "iat");
+  if (exp <= iat || exp - iat > 60) throw new InvalidPayloadError("attestation lifetime must be between one and 60 seconds");
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (iat > nowSeconds + 5) throw new InvalidPayloadError("iat claim is beyond the five-second clock tolerance");
+  const authorizationExpired = exp <= nowSeconds;
+  if (mode === "execution" && authorizationExpired) throw new ExpiredAttestationError();
+  const policyHash = requireString(payload.policyHash, "policyHash");
+  const intentHash = requireString(payload.intentHash, "intentHash");
+  if (!HEX_64.test(policyHash)) throw new InvalidPayloadError("policyHash must be lowercase SHA-256 hex");
+  if (!HEX_64.test(intentHash)) throw new InvalidPayloadError("intentHash must be lowercase SHA-256 hex");
+  if (!HEX_64.test(options.request.txCommit)) throw new InvalidPayloadError("request txCommit must be lowercase SHA-256 hex");
+  const adapter = webCryptoAdapter();
+  const recomputedCommit = await hashPgCommitV1(adapter, options.request.intent as never);
+  if (recomputedCommit !== options.request.txCommit) throw new InvalidPayloadError("request txCommit does not match pg-commit-v1 intent");
+  const recomputedIntentHash = hexFromBytes(await adapter.sha256(new TextEncoder().encode(options.request.txCommit)));
+  if (recomputedIntentHash !== intentHash) throw new InvalidPayloadError("intentHash does not bind the request txCommit");
+  return {
+    mode, authorizationExpired, protectedHeader: header as Record<string, unknown>,
+    claims: { iss: issuer, aud: trust.audience, exp, iat, kid: payloadKid, intentHash, policyHash },
+    commitment: { txCommit: recomputedCommit, intentHash: recomputedIntentHash },
+  };
+};

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -27,7 +27,7 @@ const isCanonicalBase64url = (segment: string): boolean => {
   try {
     const padding = "=".repeat((4 - (segment.length % 4)) % 4);
     const binary = atob(segment.replace(/-/g, "+").replace(/_/g, "/") + padding);
-    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "") === segment;
+    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "") === segment;
   } catch {
     return false;
   }

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -15,6 +15,20 @@ const requireInteger = (value: unknown, name: string): number => {
   return value as number;
 };
 
+const resolveVerificationMode = (value: unknown): VerificationMode => {
+  if (value === undefined) return "execution";
+  if (value === "execution" || value === "audit") return value;
+  throw new InvalidPayloadError("mode must be execution or audit");
+};
+
+const resolveNow = (value: unknown): Date => {
+  const now = value ?? new Date();
+  if (!(now instanceof Date) || !Number.isFinite(now.getTime())) {
+    throw new InvalidPayloadError("now must be a valid Date");
+  }
+  return now;
+};
+
 const hexFromBytes = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -27,7 +41,7 @@ const isCanonicalBase64url = (segment: string): boolean => {
   try {
     const padding = "=".repeat((4 - (segment.length % 4)) % 4);
     const binary = atob(segment.replace(/-/g, "+").replace(/_/g, "/") + padding);
-    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "") === segment;
+    return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "") === segment;
   } catch {
     return false;
   }
@@ -48,8 +62,8 @@ export const verifyProvingGroundAttestation = async (
   jwt: string,
   options: ProvingGroundVerificationOptions
 ): Promise<ProvingGroundVerificationResult> => {
-  const mode: VerificationMode = options.mode ?? "execution";
-  const now = options.now ?? new Date();
+  const mode = resolveVerificationMode(options.mode);
+  const now = resolveNow(options.now);
   const trust = validateTrustManifest(options.trust, now);
   assertCanonicalCompactJwt(jwt);
   const header = decodeProtectedHeader(jwt);

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -57,6 +57,71 @@ const assertCanonicalCompactJwt = (jwt: string): void => {
   }
 };
 
+const verifyJwtSignature = async (jwt: string, jwks: unknown): Promise<void> => {
+  try {
+    await compactVerify(jwt, createLocalJWKSet(jwks as Parameters<typeof createLocalJWKSet>[0]), { algorithms: ["EdDSA"] });
+  } catch (error) {
+    throw new InvalidSignatureError(error instanceof Error ? error.message : "JWT signature verification failed");
+  }
+};
+
+const validateIssuer = (payload: Record<string, unknown>, expectedIssuer: string): string => {
+  const issuer = requireString(payload.iss, "iss");
+  if (issuer !== expectedIssuer) throw new InvalidSignatureError("JWT issuer does not match the trust manifest");
+  return issuer;
+};
+
+const validateAudience = (value: unknown, expectedAudience: string): void => {
+  const includesAudience = value === expectedAudience || (Array.isArray(value) && value.includes(expectedAudience));
+  if (!includesAudience) throw new InvalidPayloadError("JWT audience must include sigil-sign");
+};
+
+const validateMatchingKid = (payload: Record<string, unknown>, headerKid: string): string => {
+  const payloadKid = requireString(payload.kid, "JWT payload kid");
+  if (payloadKid !== headerKid) throw new InvalidSignatureError("JWT header and payload kid do not match");
+  return payloadKid;
+};
+
+const readAttestationLifetime = (payload: Record<string, unknown>): { exp: number; iat: number } => {
+  const exp = requireInteger(payload.exp, "exp");
+  const iat = requireInteger(payload.iat, "iat");
+  if (exp <= iat) throw new InvalidPayloadError("attestation lifetime must be between one and 60 seconds");
+  if (exp - iat > 60) throw new InvalidPayloadError("attestation lifetime must be between one and 60 seconds");
+  return { exp, iat };
+};
+
+const validateAttestationTime = (exp: number, iat: number, mode: VerificationMode, now: Date): boolean => {
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (iat > nowSeconds + 5) throw new InvalidPayloadError("iat claim is beyond the five-second clock tolerance");
+  const authorizationExpired = exp <= nowSeconds;
+  if (mode === "execution" && authorizationExpired) throw new ExpiredAttestationError();
+  return authorizationExpired;
+};
+
+const requireSha256Hex = (value: unknown, name: string): string => {
+  const hash = requireString(value, name);
+  if (!HEX_64.test(hash)) throw new InvalidPayloadError(`${name} must be lowercase SHA-256 hex`);
+  return hash;
+};
+
+const validateAttestationClaims = (
+  payload: Record<string, unknown>,
+  issuer: string,
+  audience: string,
+  headerKid: string,
+  mode: VerificationMode,
+  now: Date
+) => {
+  const verifiedIssuer = validateIssuer(payload, issuer);
+  validateAudience(payload.aud, audience);
+  const payloadKid = validateMatchingKid(payload, headerKid);
+  const { exp, iat } = readAttestationLifetime(payload);
+  const authorizationExpired = validateAttestationTime(exp, iat, mode, now);
+  const policyHash = requireSha256Hex(payload.policyHash, "policyHash");
+  const intentHash = requireSha256Hex(payload.intentHash, "intentHash");
+  return { issuer: verifiedIssuer, payloadKid, exp, iat, authorizationExpired, policyHash, intentHash };
+};
+
 /** Verify the CC-1 profile without changing the legacy strict verifier. */
 export const verifyProvingGroundAttestation = async (
   jwt: string,
@@ -70,40 +135,18 @@ export const verifyProvingGroundAttestation = async (
   if (header.alg !== "EdDSA") throw new InvalidAlgorithmError(`Expected alg=EdDSA, got alg=${header.alg}`);
   const headerKid = requireString(header.kid, "JWT header kid");
   await assertTrustedBundleKeys(trust, options.jwks, undefined, headerKid);
-  try {
-    await compactVerify(jwt, createLocalJWKSet(options.jwks as Parameters<typeof createLocalJWKSet>[0]), { algorithms: ["EdDSA"] });
-  } catch (error) {
-    throw new InvalidSignatureError(error instanceof Error ? error.message : "JWT signature verification failed");
-  }
+  await verifyJwtSignature(jwt, options.jwks);
   const payload = decodeJwt(jwt) as Record<string, unknown>;
-  const issuer = requireString(payload.iss, "iss");
-  if (issuer !== trust.issuer) throw new InvalidSignatureError("JWT issuer does not match the trust manifest");
-  const audience = payload.aud;
-  if (audience !== trust.audience && !(Array.isArray(audience) && audience.includes(trust.audience))) {
-    throw new InvalidPayloadError("JWT audience must include sigil-sign");
-  }
-  const payloadKid = requireString(payload.kid, "JWT payload kid");
-  if (payloadKid !== headerKid) throw new InvalidSignatureError("JWT header and payload kid do not match");
-  const exp = requireInteger(payload.exp, "exp");
-  const iat = requireInteger(payload.iat, "iat");
-  if (exp <= iat || exp - iat > 60) throw new InvalidPayloadError("attestation lifetime must be between one and 60 seconds");
-  const nowSeconds = Math.floor(now.getTime() / 1000);
-  if (iat > nowSeconds + 5) throw new InvalidPayloadError("iat claim is beyond the five-second clock tolerance");
-  const authorizationExpired = exp <= nowSeconds;
-  if (mode === "execution" && authorizationExpired) throw new ExpiredAttestationError();
-  const policyHash = requireString(payload.policyHash, "policyHash");
-  const intentHash = requireString(payload.intentHash, "intentHash");
-  if (!HEX_64.test(policyHash)) throw new InvalidPayloadError("policyHash must be lowercase SHA-256 hex");
-  if (!HEX_64.test(intentHash)) throw new InvalidPayloadError("intentHash must be lowercase SHA-256 hex");
+  const claims = validateAttestationClaims(payload, trust.issuer, trust.audience, headerKid, mode, now);
   if (!HEX_64.test(options.request.txCommit)) throw new InvalidPayloadError("request txCommit must be lowercase SHA-256 hex");
   const adapter = webCryptoAdapter();
   const recomputedCommit = await hashPgCommitV1(adapter, options.request.intent as never);
   if (recomputedCommit !== options.request.txCommit) throw new InvalidPayloadError("request txCommit does not match pg-commit-v1 intent");
   const recomputedIntentHash = hexFromBytes(await adapter.sha256(new TextEncoder().encode(options.request.txCommit)));
-  if (recomputedIntentHash !== intentHash) throw new InvalidPayloadError("intentHash does not bind the request txCommit");
+  if (recomputedIntentHash !== claims.intentHash) throw new InvalidPayloadError("intentHash does not bind the request txCommit");
   return {
-    mode, authorizationExpired, protectedHeader: header as Record<string, unknown>,
-    claims: { iss: issuer, aud: trust.audience, exp, iat, kid: payloadKid, intentHash, policyHash },
+    mode, authorizationExpired: claims.authorizationExpired, protectedHeader: header as Record<string, unknown>,
+    claims: { iss: claims.issuer, aud: trust.audience, exp: claims.exp, iat: claims.iat, kid: claims.payloadKid, intentHash: claims.intentHash, policyHash: claims.policyHash },
     commitment: { txCommit: recomputedCommit, intentHash: recomputedIntentHash },
   };
 };

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -45,6 +45,13 @@ const requireDate = (value: unknown, field: string): string => {
   return text;
 };
 
+const requireVerifiedAlgorithms = (value: unknown): ["EdDSA", ...string[]] => {
+  if (!Array.isArray(value) || value.length === 0 || value[0] !== "EdDSA" || value.some((item) => typeof item !== "string")) {
+    throw new InvalidPayloadError("Trust manifest verifiedAlgorithms must begin with EdDSA and contain only strings");
+  }
+  return value as ["EdDSA", ...string[]];
+};
+
 /** RFC 7638 SHA-256 thumbprint for an Ed25519 OKP public JWK. */
 export const fingerprintJwk = async (jwk: unknown): Promise<string> => {
   if (!isRecord(jwk)) throw new InvalidPayloadError("JWK must be an object");
@@ -75,9 +82,7 @@ export const validateTrustManifest = (value: unknown, now = new Date()): SigilTr
   if (value.schema !== "sigil-trust/v1") throw new InvalidPayloadError("Unsupported trust manifest schema");
   const issuer = requireString(value.issuer, "issuer");
   if (value.audience !== "sigil-sign") throw new InvalidPayloadError("Trust manifest audience must be sigil-sign");
-  if (!Array.isArray(value.verifiedAlgorithms) || !value.verifiedAlgorithms.includes("EdDSA")) {
-    throw new InvalidPayloadError("Trust manifest must verify EdDSA");
-  }
+  const verifiedAlgorithms = requireVerifiedAlgorithms(value.verifiedAlgorithms);
   if (!Array.isArray(value.informationalAlgorithms) || value.informationalAlgorithms.some((item) => typeof item !== "string")) {
     throw new InvalidPayloadError("Trust manifest informationalAlgorithms is invalid");
   }
@@ -110,7 +115,7 @@ export const validateTrustManifest = (value: unknown, now = new Date()): SigilTr
   if (!HEX_64.test(pqcFingerprint)) throw new InvalidPayloadError("Trust PQC fingerprint is invalid");
   return {
     schema: "sigil-trust/v1", issuer, audience: "sigil-sign",
-    verifiedAlgorithms: value.verifiedAlgorithms as ["EdDSA", ...string[]],
+    verifiedAlgorithms,
     informationalAlgorithms: value.informationalAlgorithms as string[],
     notBefore, notAfter, reviewAfter, revokedAt: null, attestationKeys,
     operatorKey: { fingerprint }, pqcKey: { kid: pqcKid, fingerprint: pqcFingerprint },

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -86,6 +86,7 @@ export const fingerprintPqcRawKey = async (encodedKey: string): Promise<string> 
   return hexFromBytes(await sha256(raw));
 };
 
+// skipcq: JS-R1005 - This is the single ordered fail-closed trust boundary for manifest schema, lifetime, and key provenance.
 export const validateTrustManifest = (value: unknown, now = new Date()): SigilTrustManifestV1 => {
   const validationTime = requireValidClock(now);
   if (!isRecord(value)) throw new InvalidPayloadError("Trust manifest must be an object");
@@ -132,6 +133,7 @@ export const validateTrustManifest = (value: unknown, now = new Date()): SigilTr
   };
 };
 
+// skipcq: JS-R1005 - Each JWKS entry must be exhaustively bound to the manifest before the requested attestation key is accepted.
 export const assertTrustedBundleKeys = async (
   trust: SigilTrustManifestV1,
   jwks: unknown,
@@ -167,6 +169,7 @@ export const assertTrustedBundleKeys = async (
   }
 };
 
+// skipcq: JS-R1005 - PQC provenance has a single explicit key-selection and fingerprint boundary to avoid a weaker fallback path.
 export const assertTrustedInformationalPqcKey = async (
   trust: SigilTrustManifestV1,
   pqcKeys: unknown

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -1,0 +1,169 @@
+import type { JWK } from "jose";
+import { InvalidPayloadError, InvalidSignatureError } from "./errors.js";
+import type { SigilTrustManifestV1 } from "./types.js";
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const HEX_64 = /^[a-f0-9]{64}$/;
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const bytesFromBase64url = (value: string, label: string): Uint8Array => {
+  if (!BASE64URL.test(value)) throw new InvalidPayloadError(`${label} must be base64url encoded`);
+  try {
+    const padding = "=".repeat((4 - (value.length % 4)) % 4);
+    const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/") + padding);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    throw new InvalidPayloadError(`${label} must be base64url encoded`);
+  }
+};
+
+const base64urlFromBytes = (bytes: Uint8Array): string =>
+  btoa(String.fromCharCode(...bytes)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+
+const hexFromBytes = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const sha256 = async (bytes: Uint8Array): Promise<Uint8Array> => {
+  if (!globalThis.crypto?.subtle) throw new InvalidPayloadError("Web Crypto SHA-256 is unavailable");
+  const copy = new Uint8Array(bytes);
+  return new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", copy.buffer));
+};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new InvalidPayloadError(`Trust manifest ${field} must be a non-empty string`);
+  }
+  return value;
+};
+
+const requireDate = (value: unknown, field: string): string => {
+  const text = requireString(value, field);
+  if (!Number.isFinite(Date.parse(text))) {
+    throw new InvalidPayloadError(`Trust manifest ${field} must be an ISO timestamp`);
+  }
+  return text;
+};
+
+/** RFC 7638 SHA-256 thumbprint for an Ed25519 OKP public JWK. */
+export const fingerprintJwk = async (jwk: unknown): Promise<string> => {
+  if (!isRecord(jwk)) throw new InvalidPayloadError("JWK must be an object");
+  const kty = requireString(jwk.kty, "jwk.kty");
+  const crv = requireString(jwk.crv, "jwk.crv");
+  const x = requireString(jwk.x, "jwk.x");
+  if (kty !== "OKP" || crv !== "Ed25519" || !BASE64URL.test(x)) {
+    throw new InvalidPayloadError("JWK must be an Ed25519 OKP public key");
+  }
+  const canonical = JSON.stringify({ crv, kty, x });
+  return base64urlFromBytes(await sha256(new TextEncoder().encode(canonical)));
+};
+
+export const fingerprintEd25519RawKey = async (encodedKey: string): Promise<string> => {
+  const raw = bytesFromBase64url(encodedKey, "Ed25519 public key");
+  if (raw.length !== 32) throw new InvalidPayloadError("Ed25519 public key must be 32 bytes");
+  return hexFromBytes(await sha256(raw));
+};
+
+export const fingerprintPqcRawKey = async (encodedKey: string): Promise<string> => {
+  const raw = bytesFromBase64url(encodedKey, "PQC public key");
+  if (raw.length === 0) throw new InvalidPayloadError("PQC public key must not be empty");
+  return hexFromBytes(await sha256(raw));
+};
+
+export const validateTrustManifest = (value: unknown, now = new Date()): SigilTrustManifestV1 => {
+  if (!isRecord(value)) throw new InvalidPayloadError("Trust manifest must be an object");
+  if (value.schema !== "sigil-trust/v1") throw new InvalidPayloadError("Unsupported trust manifest schema");
+  const issuer = requireString(value.issuer, "issuer");
+  if (value.audience !== "sigil-sign") throw new InvalidPayloadError("Trust manifest audience must be sigil-sign");
+  if (!Array.isArray(value.verifiedAlgorithms) || !value.verifiedAlgorithms.includes("EdDSA")) {
+    throw new InvalidPayloadError("Trust manifest must verify EdDSA");
+  }
+  if (!Array.isArray(value.informationalAlgorithms) || value.informationalAlgorithms.some((item) => typeof item !== "string")) {
+    throw new InvalidPayloadError("Trust manifest informationalAlgorithms is invalid");
+  }
+  const notBefore = requireDate(value.notBefore, "notBefore");
+  const notAfter = requireDate(value.notAfter, "notAfter");
+  const reviewAfter = requireDate(value.reviewAfter, "reviewAfter");
+  if (Date.parse(notBefore) > now.getTime() || Date.parse(notAfter) <= now.getTime()) {
+    throw new InvalidPayloadError("Trust manifest is outside its validity window");
+  }
+  if (value.revokedAt !== null) {
+    requireDate(value.revokedAt, "revokedAt");
+    throw new InvalidSignatureError("Trust manifest has been revoked");
+  }
+  if (!Array.isArray(value.attestationKeys) || value.attestationKeys.length === 0) {
+    throw new InvalidPayloadError("Trust manifest requires attestationKeys");
+  }
+  const attestationKeys = value.attestationKeys.map((entry) => {
+    if (!isRecord(entry)) throw new InvalidPayloadError("Trust attestation key is invalid");
+    const kid = requireString(entry.kid, "attestationKeys.kid");
+    const jwkThumbprint = requireString(entry.jwkThumbprint, "attestationKeys.jwkThumbprint");
+    if (!BASE64URL.test(jwkThumbprint)) throw new InvalidPayloadError("Trust JWK thumbprint is invalid");
+    return { kid, jwkThumbprint };
+  });
+  if (!isRecord(value.operatorKey)) throw new InvalidPayloadError("Trust manifest operatorKey is required");
+  const fingerprint = requireString(value.operatorKey.fingerprint, "operatorKey.fingerprint");
+  if (!HEX_64.test(fingerprint)) throw new InvalidPayloadError("Trust operator fingerprint is invalid");
+  if (!isRecord(value.pqcKey)) throw new InvalidPayloadError("Trust manifest pqcKey is required");
+  const pqcKid = requireString(value.pqcKey.kid, "pqcKey.kid");
+  const pqcFingerprint = requireString(value.pqcKey.fingerprint, "pqcKey.fingerprint");
+  if (!HEX_64.test(pqcFingerprint)) throw new InvalidPayloadError("Trust PQC fingerprint is invalid");
+  return {
+    schema: "sigil-trust/v1", issuer, audience: "sigil-sign",
+    verifiedAlgorithms: value.verifiedAlgorithms as ["EdDSA", ...string[]],
+    informationalAlgorithms: value.informationalAlgorithms as string[],
+    notBefore, notAfter, reviewAfter, revokedAt: null, attestationKeys,
+    operatorKey: { fingerprint }, pqcKey: { kid: pqcKid, fingerprint: pqcFingerprint },
+  };
+};
+
+export const assertTrustedBundleKeys = async (
+  trust: SigilTrustManifestV1,
+  jwks: unknown,
+  operatorPublicKey: unknown | undefined,
+  expectedKid: string
+): Promise<void> => {
+  if (!isRecord(jwks) || !Array.isArray(jwks.keys)) throw new InvalidPayloadError("Bundle jwks.json must contain keys");
+  const seenKids = new Set<string>();
+  for (const candidate of jwks.keys) {
+    if (!isRecord(candidate) || typeof candidate.kid !== "string") {
+      throw new InvalidPayloadError("Every bundle JWKS entry must have a kid");
+    }
+    if (seenKids.has(candidate.kid)) throw new InvalidSignatureError("Bundle JWKS contains a duplicate kid");
+    seenKids.add(candidate.kid);
+    const trustedKey = trust.attestationKeys.find((key) => key.kid === candidate.kid);
+    if (!trustedKey || await fingerprintJwk(candidate as unknown as JWK) !== trustedKey.jwkThumbprint) {
+      throw new InvalidSignatureError("Bundle JWKS contains a key that does not match the trust manifest");
+    }
+  }
+  const expected = trust.attestationKeys.find((key) => key.kid === expectedKid);
+  if (!expected) throw new InvalidSignatureError("Attestation kid is not trusted");
+  const key = jwks.keys.find((candidate) => isRecord(candidate) && candidate.kid === expectedKid);
+  if (!key) throw new InvalidSignatureError("Bundle JWKS does not contain the attestation kid");
+  if (await fingerprintJwk(key as JWK) !== expected.jwkThumbprint) {
+    throw new InvalidSignatureError("Bundle JWKS key does not match the trust manifest");
+  }
+  if (operatorPublicKey !== undefined) {
+    if (!isRecord(operatorPublicKey)) throw new InvalidPayloadError("operator-public-key.json must be an object");
+    const x = requireString(operatorPublicKey.x, "operator-public-key.x");
+    if (await fingerprintEd25519RawKey(x) !== trust.operatorKey.fingerprint) {
+      throw new InvalidSignatureError("Bundle operator key does not match the trust manifest");
+    }
+  }
+};
+
+export const assertTrustedInformationalPqcKey = async (
+  trust: SigilTrustManifestV1,
+  pqcKeys: unknown
+): Promise<void> => {
+  if (!isRecord(pqcKeys) || !Array.isArray(pqcKeys.keys)) {
+    throw new InvalidPayloadError("Bundle pqc-keys.json must contain keys");
+  }
+  const key = pqcKeys.keys.find((candidate) => isRecord(candidate) && candidate.kid === trust.pqcKey.kid);
+  if (!isRecord(key) || key.kty !== "ML-DSA" || key.alg !== "ML-DSA-65" || typeof key.publicKey !== "string") {
+    throw new InvalidSignatureError("Bundle PQC key does not match the trust manifest");
+  }
+  if (await fingerprintPqcRawKey(key.publicKey) !== trust.pqcKey.fingerprint) {
+    throw new InvalidSignatureError("Bundle PQC key does not match the trust manifest");
+  }
+};

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -4,6 +4,7 @@ import type { SigilTrustManifestV1 } from "./types.js";
 
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 const HEX_64 = /^[a-f0-9]{64}$/;
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
@@ -39,10 +40,18 @@ const requireString = (value: unknown, field: string): string => {
 
 const requireDate = (value: unknown, field: string): string => {
   const text = requireString(value, field);
-  if (!Number.isFinite(Date.parse(text))) {
+  const calendarDate = text.slice(0, 10);
+  if (!ISO_8601_TIMESTAMP.test(text) || !Number.isFinite(Date.parse(text)) || new Date(`${calendarDate}T00:00:00Z`).toISOString().slice(0, 10) !== calendarDate) {
     throw new InvalidPayloadError(`Trust manifest ${field} must be an ISO timestamp`);
   }
   return text;
+};
+
+const requireValidClock = (value: unknown): Date => {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new InvalidPayloadError("Trust manifest validation time must be a valid Date");
+  }
+  return value;
 };
 
 const requireVerifiedAlgorithms = (value: unknown): ["EdDSA", ...string[]] => {
@@ -78,6 +87,7 @@ export const fingerprintPqcRawKey = async (encodedKey: string): Promise<string> 
 };
 
 export const validateTrustManifest = (value: unknown, now = new Date()): SigilTrustManifestV1 => {
+  const validationTime = requireValidClock(now);
   if (!isRecord(value)) throw new InvalidPayloadError("Trust manifest must be an object");
   if (value.schema !== "sigil-trust/v1") throw new InvalidPayloadError("Unsupported trust manifest schema");
   const issuer = requireString(value.issuer, "issuer");
@@ -89,7 +99,7 @@ export const validateTrustManifest = (value: unknown, now = new Date()): SigilTr
   const notBefore = requireDate(value.notBefore, "notBefore");
   const notAfter = requireDate(value.notAfter, "notAfter");
   const reviewAfter = requireDate(value.reviewAfter, "reviewAfter");
-  if (Date.parse(notBefore) > now.getTime() || Date.parse(notAfter) <= now.getTime()) {
+  if (Date.parse(notBefore) > validationTime.getTime() || Date.parse(notAfter) <= validationTime.getTime()) {
     throw new InvalidPayloadError("Trust manifest is outside its validity window");
   }
   if (value.revokedAt !== null) {

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -19,7 +19,7 @@ const bytesFromBase64url = (value: string, label: string): Uint8Array => {
 };
 
 const base64urlFromBytes = (bytes: Uint8Array): string =>
-  btoa(String.fromCharCode(...bytes)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
+  btoa(String.fromCharCode(...bytes)).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 
 const hexFromBytes = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -19,7 +19,7 @@ const bytesFromBase64url = (value: string, label: string): Uint8Array => {
 };
 
 const base64urlFromBytes = (bytes: Uint8Array): string =>
-  btoa(String.fromCharCode(...bytes)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  btoa(String.fromCharCode(...bytes)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
 
 const hexFromBytes = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,58 @@ export interface VerifiedAttestation {
   };
   intent: Intent;
 }
+
+export type VerificationMode = "execution" | "audit";
+
+export interface TrustAttestationKey {
+  kid: string;
+  jwkThumbprint: string;
+}
+
+export interface TrustPqcKey {
+  kid: string;
+  fingerprint: string;
+}
+
+export interface SigilTrustManifestV1 {
+  schema: "sigil-trust/v1";
+  issuer: string;
+  audience: "sigil-sign";
+  verifiedAlgorithms: ["EdDSA", ...string[]];
+  informationalAlgorithms: string[];
+  notBefore: string;
+  notAfter: string;
+  reviewAfter: string;
+  revokedAt: string | null;
+  attestationKeys: TrustAttestationKey[];
+  operatorKey: { fingerprint: string };
+  pqcKey: TrustPqcKey;
+}
+
+export interface ProvingGroundVerificationOptions {
+  trust: SigilTrustManifestV1;
+  request: { intent: unknown; txCommit: string };
+  jwks: unknown;
+  mode?: VerificationMode;
+  now?: Date;
+}
+
+export interface ProvingGroundVerificationResult {
+  mode: VerificationMode;
+  authorizationExpired: boolean;
+  protectedHeader: Record<string, unknown>;
+  claims: { iss: string; aud: string; exp: number; iat: number; kid: string; intentHash: string; policyHash: string };
+  commitment: { txCommit: string; intentHash: string };
+}
+
+export interface VerifyBundleOptions {
+  bundlePath: string;
+  trust: SigilTrustManifestV1;
+  mode?: VerificationMode;
+  now?: Date;
+}
+
+export interface VerifyBundleResult extends ProvingGroundVerificationResult {
+  operatorSignatureValid: true;
+  derivedPolicyHash: string;
+}

--- a/tests/browser-root-import.test.ts
+++ b/tests/browser-root-import.test.ts
@@ -1,10 +1,11 @@
 import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 describe("browser and Workers root import", () => {
   it("bundles the public root without Node-only modules", async () => {
     const result = await build({
-      entryPoints: [new URL("../src/index.ts", import.meta.url).pathname],
+      entryPoints: [fileURLToPath(new URL("../src/index.ts", import.meta.url))],
       bundle: true,
       format: "esm",
       platform: "browser",

--- a/tests/browser-root-import.test.ts
+++ b/tests/browser-root-import.test.ts
@@ -1,0 +1,18 @@
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("browser and Workers root import", () => {
+  it("bundles the public root without Node-only modules", async () => {
+    const result = await build({
+      entryPoints: [new URL("../src/index.ts", import.meta.url).pathname],
+      bundle: true,
+      format: "esm",
+      platform: "browser",
+      write: false,
+    });
+    const output = result.outputFiles[0]?.text ?? "";
+    expect(output).not.toContain("node:crypto");
+    expect(output).not.toContain("node:fs");
+    expect(output).not.toContain("node:path");
+  });
+});

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -21,10 +21,18 @@ describe("final promotion workflow", () => {
 
   it("attests candidate artifacts with a credential-free checkout", async () => {
     const workflow = await readFile(releaseWorkflowPath, "utf8");
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(workflow).toContain("build:");
+    expect(workflow).toContain("release:\n    needs: build");
     expect(workflow).toContain("persist-credentials: false");
     expect(workflow).toContain("id-token: write");
     expect(workflow).toContain("attestations: write");
+    expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02");
+    expect(workflow).toContain("actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093");
+    expect(workflow).toContain('git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}"');
+    expect(workflow).toContain('= "$GITHUB_SHA"');
     expect(workflow).toContain("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6");
     expect(workflow).toContain("subject-path:");
+    expect(workflow).not.toContain('gh release view "$GITHUB_REF_NAME"');
   });
 });

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -21,6 +21,7 @@ describe("final promotion workflow", () => {
 
   it("attests candidate artifacts with a credential-free checkout", async () => {
     const workflow = await readFile(releaseWorkflowPath, "utf8");
+    const githubRefName = shellVariable("GITHUB_REF_NAME");
     expect(workflow).toContain("permissions:\n  contents: read");
     expect(workflow).toContain("build:");
     expect(workflow).toContain("release:\n    needs: build");
@@ -29,7 +30,7 @@ describe("final promotion workflow", () => {
     expect(workflow).toContain("attestations: write");
     expect(workflow).toContain("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02");
     expect(workflow).toContain("actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093");
-    expect(workflow).toContain('git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}"');
+    expect(workflow).toContain(`git rev-parse "refs/tags/${githubRefName}^{commit}"`);
     expect(workflow).toContain('= "$GITHUB_SHA"');
     expect(workflow).toContain("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6");
     expect(workflow).toContain("subject-path:");

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -3,19 +3,20 @@ import { describe, expect, it } from "vitest";
 
 const workflowPath = new URL("../.github/workflows/promote-final.yml", import.meta.url);
 const releaseWorkflowPath = new URL("../.github/workflows/release-rc.yml", import.meta.url);
+const shellVariable = (name: string): string => [String.fromCharCode(36), "{", name, "}"].join("");
 
 describe("final promotion workflow", () => {
   it("requires one same-commit immutable candidate release", async () => {
     const workflow = await readFile(workflowPath, "utf8");
-    const finalTagVariable = "$" + "{FINAL_TAG}";
-    const candidateTagsVariable = "$" + "{#candidate_tags[@]}";
-    const candidateOutput = "$" + "{{ steps.candidate.outputs.tag }}";
-    expect(workflow).toContain('git tag --points-at "$final_commit" --list "' + finalTagVariable + '-rc.*"');
-    expect(workflow).toContain('[ "' + candidateTagsVariable + '" -ne 1 ]');
+    const finalTagVariable = shellVariable("FINAL_TAG");
+    const candidateTagsVariable = shellVariable("#candidate_tags[@]");
+    const candidateOutput = [String.fromCharCode(36), "{{ steps.candidate.outputs.tag }}"].join("");
+    expect(workflow).toContain(['git tag --points-at "$final_commit" --list "', finalTagVariable, '-rc.*"'].join(""));
+    expect(workflow).toContain(['[ "', candidateTagsVariable, '" -ne 1 ]'].join(""));
     expect(workflow).toContain('gh release view "$candidate_tag"');
-    expect(workflow).toContain("CANDIDATE_TAG: " + candidateOutput);
+    expect(workflow).toContain(["CANDIDATE_TAG: ", candidateOutput].join(""));
     expect(workflow).toContain("gh attestation verify");
-    expect(workflow).not.toContain('candidate_tag="' + finalTagVariable + '-rc.1"');
+    expect(workflow).not.toContain(['candidate_tag="', finalTagVariable, '-rc.1"'].join(""));
   });
 
   it("attests candidate artifacts with a credential-free checkout", async () => {

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -2,14 +2,28 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 const workflowPath = new URL("../.github/workflows/promote-final.yml", import.meta.url);
+const releaseWorkflowPath = new URL("../.github/workflows/release-rc.yml", import.meta.url);
 
 describe("final promotion workflow", () => {
   it("requires one same-commit immutable candidate release", async () => {
     const workflow = await readFile(workflowPath, "utf8");
-    expect(workflow).toContain('git tag --points-at "$final_commit" --list "${FINAL_TAG}-rc.*"');
-    expect(workflow).toContain('[ "${#candidate_tags[@]}" -ne 1 ]');
+    const finalTagVariable = "$" + "{FINAL_TAG}";
+    const candidateTagsVariable = "$" + "{#candidate_tags[@]}";
+    const candidateOutput = "$" + "{{ steps.candidate.outputs.tag }}";
+    expect(workflow).toContain('git tag --points-at "$final_commit" --list "' + finalTagVariable + '-rc.*"');
+    expect(workflow).toContain('[ "' + candidateTagsVariable + '" -ne 1 ]');
     expect(workflow).toContain('gh release view "$candidate_tag"');
-    expect(workflow).toContain('CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}');
-    expect(workflow).not.toContain('candidate_tag="${FINAL_TAG}-rc.1"');
+    expect(workflow).toContain("CANDIDATE_TAG: " + candidateOutput);
+    expect(workflow).toContain("gh attestation verify");
+    expect(workflow).not.toContain('candidate_tag="' + finalTagVariable + '-rc.1"');
+  });
+
+  it("attests candidate artifacts with a credential-free checkout", async () => {
+    const workflow = await readFile(releaseWorkflowPath, "utf8");
+    expect(workflow).toContain("persist-credentials: false");
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("attestations: write");
+    expect(workflow).toContain("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6");
+    expect(workflow).toContain("subject-path:");
   });
 });

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const workflowPath = new URL("../.github/workflows/promote-final.yml", import.meta.url);
+
+describe("final promotion workflow", () => {
+  it("requires one same-commit immutable candidate release", async () => {
+    const workflow = await readFile(workflowPath, "utf8");
+    expect(workflow).toContain('git tag --points-at "$final_commit" --list "${FINAL_TAG}-rc.*"');
+    expect(workflow).toContain('[ "${#candidate_tags[@]}" -ne 1 ]');
+    expect(workflow).toContain('gh release view "$candidate_tag"');
+    expect(workflow).toContain('CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}');
+    expect(workflow).not.toContain('candidate_tag="${FINAL_TAG}-rc.1"');
+  });
+});

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -16,7 +16,7 @@ const directories: string[] = [];
 const NOW = new Date("2030-01-01T00:00:00Z");
 const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
 const WARRANTY = "version: 2.1.0\n\n## tool_calls\nallowed: web_fetch\n";
-const INTENT = { action: "web_fetch", url: "https://docs.sigilcore.com/getting-started", metadata: { job_type: "documentation" } };
+const INTENT = { action: "web_fetch", chainId: 1, url: "https://docs.sigilcore.com/getting-started", metadata: { job_type: "documentation" } };
 
 afterEach(async () => {
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
@@ -25,11 +25,11 @@ afterEach(async () => {
 const PQC_KEY = { kty: "ML-DSA", alg: "ML-DSA-65", kid: "synthetic-pqc", publicKey: "AQIDBA", use: "sig" };
 
 // skipcq: JS-R1005 - The fixture creates one cryptographically linked offline bundle so every negative test mutates a consistent baseline.
-const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; operatorJwk?: Record<string, unknown>; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string } = {}) => {
+const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string } = {}) => {
   const signer = await generateKeyPair("EdDSA");
   const operator = await generateKeyPair("EdDSA");
   const signerJwk = await exportJWK(signer.publicKey);
-  const operatorJwk = (overrides.operatorJwk ?? await exportJWK(operator.publicKey)) as Record<string, unknown>;
+  const operatorJwk = await exportJWK(operator.publicKey) as Record<string, unknown>;
   const kid = "synthetic-signer";
   const policy = parsePolicyMarkdown(overrides.warranty ?? WARRANTY);
   const policyHash = await hashPolicy(createNodeCryptoAdapter(), policy);
@@ -163,6 +163,19 @@ describe("Proving Ground verifier profile", () => {
     const artifact = await makeArtifacts();
     await writeFile(join(artifact.directory, "request.json"), JSON.stringify({ intent: { ...INTENT, action: "email.send" }, txCommit: artifact.txCommit }));
     await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("does not match pg-commit-v1 intent");
+  });
+
+  it("rejects a request that differs only by chain", async () => {
+    const artifact = await makeArtifacts();
+    await writeFile(join(artifact.directory, "request.json"), JSON.stringify({
+      intent: { ...INTENT, chainId: 8453 },
+      txCommit: artifact.txCommit,
+    }));
+    await expect(verifyProofBundle({
+      bundlePath: artifact.directory,
+      trust: artifact.trust,
+      now: NOW,
+    })).rejects.toThrow("does not match pg-commit-v1 intent");
   });
 
   it("rejects a changed commitment, policy hash, or JWT signature", async () => {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -10,7 +10,7 @@ import { verifyProvingGroundAttestation } from "../src/index.js";
 import { verifyProofBundle } from "../src/node.js";
 import { CANONICALIZER_VERSION, CANONICAL_POLICY_ENVELOPE_SCHEMA } from "../src/bundle.js";
 import { fingerprintEd25519RawKey, fingerprintJwk, fingerprintPqcRawKey } from "../src/trust.js";
-import type { SigilTrustManifestV1 } from "../src/types.js";
+import type { SigilTrustManifestV1, VerificationMode } from "../src/types.js";
 
 const directories: string[] = [];
 const NOW = new Date("2030-01-01T00:00:00Z");
@@ -87,6 +87,24 @@ describe("Proving Ground verifier profile", () => {
     const artifact = await makeArtifacts({ expiresAt: NOW_SECONDS - 1 });
     await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("JWT has expired");
     await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, mode: "audit", now: NOW })).resolves.toMatchObject({ authorizationExpired: true });
+  });
+
+  it("rejects invalid modes and clocks before temporal checks", async () => {
+    const expired = await makeArtifacts({ expiresAt: NOW_SECONDS - 1 });
+    const request = { intent: INTENT, txCommit: expired.txCommit };
+    await expect(verifyProvingGroundAttestation(expired.jwt, {
+      trust: expired.trust,
+      jwks: expired.jwks,
+      request,
+      mode: "unsupported" as VerificationMode,
+      now: NOW,
+    })).rejects.toThrow("mode must be execution or audit");
+    await expect(verifyProvingGroundAttestation(expired.jwt, {
+      trust: expired.trust,
+      jwks: expired.jwks,
+      request,
+      now: new Date("invalid"),
+    })).rejects.toThrow("now must be a valid Date");
   });
 
   it("rejects a tampered request intent", async () => {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
-import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { decodeJwt, exportJWK, generateKeyPair, SignJWT } from "jose";
 import { appendSignatureBlock, hashPgCommitV1, hashPolicy, parsePolicyMarkdown } from "@sigilcore/warrant-core";
 import { createNodeCryptoAdapter } from "@sigilcore/warrant-core/crypto/node";
 import { verifyProvingGroundAttestation } from "../src/index.js";
@@ -71,7 +71,7 @@ const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audien
     })),
     writeFile(join(directory, "VERIFY.md"), "Synthetic verifier instructions only.\n"),
   ]);
-  return { directory, trust, jwt, jwks: { keys: [{ ...signerJwk, kid, alg: "EdDSA", use: "sig" }] }, txCommit };
+  return { directory, trust, jwt, privateKey: signer.privateKey, jwks: { keys: [{ ...signerJwk, kid, alg: "EdDSA", use: "sig" }] }, txCommit };
 };
 
 describe("Proving Ground verifier profile", () => {
@@ -114,6 +114,37 @@ describe("Proving Ground verifier profile", () => {
     const artifact = await makeArtifacts();
     const trust = { ...artifact.trust, verifiedAlgorithms };
     expect(() => validateTrustManifest(trust, NOW)).toThrow("verifiedAlgorithms must begin with EdDSA and contain only strings");
+  });
+
+  it("rejects malformed JWTs and required claims before commitment checks", async () => {
+    const artifact = await makeArtifacts();
+    const request = { intent: INTENT, txCommit: artifact.txCommit };
+    await expect(verifyProvingGroundAttestation("not-a-jwt", {
+      trust: artifact.trust, jwks: artifact.jwks, request, now: NOW,
+    })).rejects.toThrow("compact base64url serialization");
+    const withoutHeaderKid = await new SignJWT(decodeJwt(artifact.jwt))
+      .setProtectedHeader({ alg: "EdDSA" })
+      .sign(artifact.privateKey);
+    await expect(verifyProvingGroundAttestation(withoutHeaderKid, {
+      trust: artifact.trust, jwks: artifact.jwks, request, now: NOW,
+    })).rejects.toThrow("JWT header kid must be a non-empty string");
+    for (const claim of ["kid", "exp", "iat", "intentHash"]) {
+      const payload = decodeJwt(artifact.jwt) as Record<string, unknown>;
+      delete payload[claim];
+      const jwt = await new SignJWT(payload)
+        .setProtectedHeader({ alg: "EdDSA", kid: "synthetic-signer" })
+        .sign(artifact.privateKey);
+      await expect(verifyProvingGroundAttestation(jwt, {
+        trust: artifact.trust, jwks: artifact.jwks, request, now: NOW,
+      })).rejects.toThrow();
+    }
+  });
+
+  it("rejects invalid standalone trust clocks and timestamps before bundle parsing", async () => {
+    const artifact = await makeArtifacts();
+    expect(() => validateTrustManifest(artifact.trust, new Date("invalid"))).toThrow("validation time must be a valid Date");
+    expect(() => validateTrustManifest({ ...artifact.trust, notBefore: "2029-02-29T00:00:00Z" }, NOW)).toThrow("notBefore must be an ISO timestamp");
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: {} as SigilTrustManifestV1, now: NOW })).rejects.toThrow("Unsupported trust manifest schema");
   });
 
   it("rejects a tampered request intent", async () => {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -128,9 +128,14 @@ describe("Proving Ground verifier profile", () => {
     await expect(verifyProvingGroundAttestation(withoutHeaderKid, {
       trust: artifact.trust, jwks: artifact.jwks, request, now: NOW,
     })).rejects.toThrow("JWT header kid must be a non-empty string");
-    for (const claim of ["kid", "exp", "iat", "intentHash"]) {
-      const payload = decodeJwt(artifact.jwt) as Record<string, unknown>;
-      delete payload[claim];
+    const omitRequiredClaim = {
+      kid: ({ kid: _kid, ...payload }: Record<string, unknown>) => payload,
+      exp: ({ exp: _exp, ...payload }: Record<string, unknown>) => payload,
+      iat: ({ iat: _iat, ...payload }: Record<string, unknown>) => payload,
+      intentHash: ({ intentHash: _intentHash, ...payload }: Record<string, unknown>) => payload,
+    };
+    for (const omitClaim of Object.values(omitRequiredClaim)) {
+      const payload = omitClaim(decodeJwt(artifact.jwt) as Record<string, unknown>);
       const jwt = await new SignJWT(payload)
         .setProtectedHeader({ alg: "EdDSA", kid: "synthetic-signer" })
         .sign(artifact.privateKey);
@@ -145,6 +150,12 @@ describe("Proving Ground verifier profile", () => {
     expect(() => validateTrustManifest(artifact.trust, new Date("invalid"))).toThrow("validation time must be a valid Date");
     expect(() => validateTrustManifest({ ...artifact.trust, notBefore: "2029-02-29T00:00:00Z" }, NOW)).toThrow("notBefore must be an ISO timestamp");
     await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: {} as SigilTrustManifestV1, now: NOW })).rejects.toThrow("Unsupported trust manifest schema");
+  });
+
+  it("rejects response attestations that differ from the exact JWT file bytes", async () => {
+    const artifact = await makeArtifacts();
+    await writeFile(join(artifact.directory, "attestation.jwt"), ` ${artifact.jwt}\n`);
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("response.json intent_attestation does not match attestation.jwt");
   });
 
   it("rejects a tampered request intent", async () => {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -9,7 +9,7 @@ import { createNodeCryptoAdapter } from "@sigilcore/warrant-core/crypto/node";
 import { verifyProvingGroundAttestation } from "../src/index.js";
 import { verifyProofBundle } from "../src/node.js";
 import { CANONICALIZER_VERSION, CANONICAL_POLICY_ENVELOPE_SCHEMA } from "../src/bundle.js";
-import { fingerprintEd25519RawKey, fingerprintJwk, fingerprintPqcRawKey } from "../src/trust.js";
+import { fingerprintEd25519RawKey, fingerprintJwk, fingerprintPqcRawKey, validateTrustManifest } from "../src/trust.js";
 import type { SigilTrustManifestV1, VerificationMode } from "../src/types.js";
 
 const directories: string[] = [];
@@ -105,6 +105,15 @@ describe("Proving Ground verifier profile", () => {
       request,
       now: new Date("invalid"),
     })).rejects.toThrow("now must be a valid Date");
+  });
+
+  it.each([
+    ["a non-string value", ["EdDSA", null]],
+    ["an array without EdDSA first", ["RS256", "EdDSA"]],
+  ])("rejects verifiedAlgorithms with %s", async (_label, verifiedAlgorithms) => {
+    const artifact = await makeArtifacts();
+    const trust = { ...artifact.trust, verifiedAlgorithms };
+    expect(() => validateTrustManifest(trust, NOW)).toThrow("verifiedAlgorithms must begin with EdDSA and contain only strings");
   });
 
   it("rejects a tampered request intent", async () => {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -24,6 +24,7 @@ afterEach(async () => {
 
 const PQC_KEY = { kty: "ML-DSA", alg: "ML-DSA-65", kid: "synthetic-pqc", publicKey: "AQIDBA", use: "sig" };
 
+// skipcq: JS-R1005 - The fixture creates one cryptographically linked offline bundle so every negative test mutates a consistent baseline.
 const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; operatorJwk?: Record<string, unknown>; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string } = {}) => {
   const signer = await generateKeyPair("EdDSA");
   const operator = await generateKeyPair("EdDSA");

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -1,0 +1,182 @@
+import { createHash, sign as signBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { appendSignatureBlock, hashPgCommitV1, hashPolicy, parsePolicyMarkdown } from "@sigilcore/warrant-core";
+import { createNodeCryptoAdapter } from "@sigilcore/warrant-core/crypto/node";
+import { verifyProvingGroundAttestation } from "../src/index.js";
+import { verifyProofBundle } from "../src/node.js";
+import { CANONICALIZER_VERSION, CANONICAL_POLICY_ENVELOPE_SCHEMA } from "../src/bundle.js";
+import { fingerprintEd25519RawKey, fingerprintJwk, fingerprintPqcRawKey } from "../src/trust.js";
+import type { SigilTrustManifestV1 } from "../src/types.js";
+
+const directories: string[] = [];
+const NOW = new Date("2030-01-01T00:00:00Z");
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
+const WARRANTY = "version: 2.1.0\n\n## tool_calls\nallowed: web_fetch\n";
+const INTENT = { action: "web_fetch", url: "https://docs.sigilcore.com/getting-started", metadata: { job_type: "documentation" } };
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+const PQC_KEY = { kty: "ML-DSA", alg: "ML-DSA-65", kid: "synthetic-pqc", publicKey: "AQIDBA", use: "sig" };
+
+const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; operatorJwk?: Record<string, unknown>; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string } = {}) => {
+  const signer = await generateKeyPair("EdDSA");
+  const operator = await generateKeyPair("EdDSA");
+  const signerJwk = await exportJWK(signer.publicKey);
+  const operatorJwk = (overrides.operatorJwk ?? await exportJWK(operator.publicKey)) as Record<string, unknown>;
+  const kid = "synthetic-signer";
+  const policy = parsePolicyMarkdown(overrides.warranty ?? WARRANTY);
+  const policyHash = await hashPolicy(createNodeCryptoAdapter(), policy);
+  const txCommit = await hashPgCommitV1(createNodeCryptoAdapter(), INTENT);
+  const intentHash = createHash("sha256").update(txCommit, "utf8").digest("hex");
+  const jwt = await new SignJWT({
+    aud: overrides.audience ?? "sigil-sign", kid: overrides.payloadKid ?? kid, intentHash, policyHash: overrides.attestationPolicyHash ?? policyHash,
+    agentId: "synthetic-agent", framework: "synthetic", provenance: "agent",
+  })
+    .setProtectedHeader({ alg: "EdDSA", kid })
+    .setIssuer("sigil-core")
+    .setIssuedAt(NOW_SECONDS - 10)
+    .setExpirationTime(overrides.expiresAt ?? NOW_SECONDS + 50)
+    .sign(signer.privateKey);
+  const unsigned = overrides.warranty ?? WARRANTY;
+  const signature = signBytes(null, Buffer.from(unsigned.trimEnd(), "utf8"), operator.privateKey).toString("base64url");
+  const warranty = appendSignatureBlock(unsigned, signature);
+  const trust: SigilTrustManifestV1 = {
+    schema: "sigil-trust/v1", issuer: "sigil-core", audience: "sigil-sign",
+    verifiedAlgorithms: ["EdDSA"], informationalAlgorithms: ["ML-DSA-65"],
+    notBefore: "2029-01-01T00:00:00Z", notAfter: "2031-01-01T00:00:00Z", reviewAfter: "2030-06-01T00:00:00Z", revokedAt: null,
+    attestationKeys: [{ kid, jwkThumbprint: await fingerprintJwk(signerJwk) }],
+    operatorKey: { fingerprint: await fingerprintEd25519RawKey(operatorJwk.x as string) },
+    pqcKey: { kid: PQC_KEY.kid, fingerprint: await fingerprintPqcRawKey(PQC_KEY.publicKey) },
+  };
+  const directory = await mkdtemp(join(tmpdir(), "sigil-proof-"));
+  directories.push(directory);
+  await Promise.all([
+    writeFile(join(directory, "warranty.md"), warranty),
+    writeFile(join(directory, "operator-public-key.json"), JSON.stringify(operatorJwk)),
+    writeFile(join(directory, "attestation.jwt"), jwt),
+    writeFile(join(directory, "request.json"), JSON.stringify({ intent: INTENT, txCommit })),
+    writeFile(join(directory, "response.json"), JSON.stringify({ intent_attestation: overrides.responseAttestation ?? jwt })),
+    writeFile(join(directory, "jwks.json"), JSON.stringify(overrides.jwks ?? { keys: [{ ...signerJwk, kid, alg: "EdDSA", use: "sig" }] })),
+    writeFile(join(directory, "pqc-keys.json"), JSON.stringify(overrides.pqcKeys ?? { keys: [PQC_KEY] })),
+    writeFile(join(directory, "policy.canonical.json"), JSON.stringify(overrides.canonical ?? {
+      schema: CANONICAL_POLICY_ENVELOPE_SCHEMA,
+      canonicalizer: CANONICALIZER_VERSION,
+      policy,
+    })),
+    writeFile(join(directory, "VERIFY.md"), "Synthetic verifier instructions only.\n"),
+  ]);
+  return { directory, trust, jwt, jwks: { keys: [{ ...signerJwk, kid, alg: "EdDSA", use: "sig" }] }, txCommit };
+};
+
+describe("Proving Ground verifier profile", () => {
+  it("proves the complete synthetic offline chain", async () => {
+    const artifact = await makeArtifacts();
+    const result = await verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW });
+    expect(result.operatorSignatureValid).toBe(true);
+    expect(result.authorizationExpired).toBe(false);
+    expect(result.commitment.txCommit).toBe(artifact.txCommit);
+  });
+
+  it("keeps execution expiry strict while audit mode verifies historical proof", async () => {
+    const artifact = await makeArtifacts({ expiresAt: NOW_SECONDS - 1 });
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("JWT has expired");
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, mode: "audit", now: NOW })).resolves.toMatchObject({ authorizationExpired: true });
+  });
+
+  it("rejects a tampered request intent", async () => {
+    const artifact = await makeArtifacts();
+    await writeFile(join(artifact.directory, "request.json"), JSON.stringify({ intent: { ...INTENT, action: "email.send" }, txCommit: artifact.txCommit }));
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("does not match pg-commit-v1 intent");
+  });
+
+  it("rejects a changed commitment, policy hash, or JWT signature", async () => {
+    const commitment = await makeArtifacts();
+    await writeFile(join(commitment.directory, "request.json"), JSON.stringify({ intent: INTENT, txCommit: "a".repeat(64) }));
+    await expect(verifyProofBundle({ bundlePath: commitment.directory, trust: commitment.trust, now: NOW })).rejects.toThrow("does not match pg-commit-v1 intent");
+    const policy = await makeArtifacts({ attestationPolicyHash: "b".repeat(64) });
+    await expect(verifyProofBundle({ bundlePath: policy.directory, trust: policy.trust, now: NOW })).rejects.toThrow("Derived policyHash does not match");
+    const signature = await makeArtifacts();
+    const [header, payload, encodedSignature] = signature.jwt.split(".");
+    const changedSignature = `${encodedSignature[0] === "A" ? "B" : "A"}${encodedSignature.slice(1)}`;
+    await writeFile(join(signature.directory, "attestation.jwt"), `${header}.${payload}.${changedSignature}`);
+    await expect(verifyProofBundle({ bundlePath: signature.directory, trust: signature.trust, now: NOW })).rejects.toThrow();
+  });
+
+  it.each(["not-a-sha256-digest", "A".repeat(64)])(
+    "rejects invalid direct-profile policyHash %s",
+    async (policyHash) => {
+      const artifact = await makeArtifacts({ attestationPolicyHash: policyHash });
+      await expect(verifyProvingGroundAttestation(artifact.jwt, {
+        trust: artifact.trust,
+        jwks: artifact.jwks,
+        request: { intent: INTENT, txCommit: artifact.txCommit },
+        now: NOW,
+      })).rejects.toThrow("policyHash must be lowercase SHA-256 hex");
+    }
+  );
+
+  it("rejects a mismatched audience", async () => {
+    const artifact = await makeArtifacts({ audience: "wrong-audience" });
+    await expect(verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW })).rejects.toThrow("audience must include sigil-sign");
+  });
+
+  it("rejects trust substitution, unknown kids, and header/payload kid mismatch", async () => {
+    const swapped = await makeArtifacts();
+    const replacement = await generateKeyPair("EdDSA");
+    const replacementJwk = await exportJWK(replacement.publicKey);
+    await writeFile(join(swapped.directory, "jwks.json"), JSON.stringify({ keys: [{ ...replacementJwk, kid: "synthetic-signer", alg: "EdDSA", use: "sig" }] }));
+    await expect(verifyProofBundle({ bundlePath: swapped.directory, trust: swapped.trust, now: NOW })).rejects.toThrow("does not match the trust manifest");
+    const unknown = await makeArtifacts();
+    unknown.trust.attestationKeys[0].kid = "unknown";
+    await expect(verifyProofBundle({ bundlePath: unknown.directory, trust: unknown.trust, now: NOW })).rejects.toThrow("does not match the trust manifest");
+    const duplicate = await makeArtifacts();
+    const duplicateJwks = JSON.parse(await readFile(join(duplicate.directory, "jwks.json"), "utf8"));
+    duplicateJwks.keys.push({ ...duplicateJwks.keys[0], x: "A".repeat(43) });
+    await writeFile(join(duplicate.directory, "jwks.json"), JSON.stringify(duplicateJwks));
+    await expect(verifyProofBundle({ bundlePath: duplicate.directory, trust: duplicate.trust, now: NOW })).rejects.toThrow("duplicate kid");
+    const mismatch = await makeArtifacts({ payloadKid: "different-kid" });
+    await expect(verifyProofBundle({ bundlePath: mismatch.directory, trust: mismatch.trust, now: NOW })).rejects.toThrow("header and payload kid do not match");
+  });
+
+  it("rejects a substituted operator key and supplied-canonical-only bundle", async () => {
+    const otherOperator = await generateKeyPair("EdDSA");
+    const otherOperatorJwk = await exportJWK(otherOperator.publicKey);
+    const substituted = await makeArtifacts();
+    await writeFile(join(substituted.directory, "operator-public-key.json"), JSON.stringify(otherOperatorJwk));
+    await expect(verifyProofBundle({ bundlePath: substituted.directory, trust: substituted.trust, now: NOW })).rejects.toThrow("operator key does not match");
+    const canonicalOnly = await makeArtifacts({ canonical: {
+      schema: CANONICAL_POLICY_ENVELOPE_SCHEMA,
+      canonicalizer: CANONICALIZER_VERSION,
+      policy: { version: "2.1.0", tool_calls: { allowed: ["email.send"] } },
+    } });
+    await expect(verifyProofBundle({ bundlePath: canonicalOnly.directory, trust: canonicalOnly.trust, now: NOW })).rejects.toThrow("not derived from warranty.md");
+  });
+
+  it("binds the response, canonicalizer, PQC snapshot, and trust lifecycle", async () => {
+    const responseMismatch = await makeArtifacts({ responseAttestation: "not-the-attestation" });
+    await expect(verifyProofBundle({ bundlePath: responseMismatch.directory, trust: responseMismatch.trust, now: NOW })).rejects.toThrow("response.json intent_attestation");
+
+    const canonicalizerMismatch = await makeArtifacts();
+    const canonical = JSON.parse(await readFile(join(canonicalizerMismatch.directory, "policy.canonical.json"), "utf8"));
+    canonical.canonicalizer = "@sigilcore/warrant-core@999.0.0";
+    await writeFile(join(canonicalizerMismatch.directory, "policy.canonical.json"), JSON.stringify(canonical));
+    await expect(verifyProofBundle({ bundlePath: canonicalizerMismatch.directory, trust: canonicalizerMismatch.trust, now: NOW })).rejects.toThrow("unsupported canonicalizer envelope");
+
+    const pqcSubstitution = await makeArtifacts({ pqcKeys: { keys: [{ ...PQC_KEY, publicKey: "BQYHCA" }] } });
+    await expect(verifyProofBundle({ bundlePath: pqcSubstitution.directory, trust: pqcSubstitution.trust, now: NOW })).rejects.toThrow("PQC key does not match");
+
+    const expiredTrust = await makeArtifacts();
+    expiredTrust.trust.notAfter = "2029-12-31T23:59:59Z";
+    await expect(verifyProofBundle({ bundlePath: expiredTrust.directory, trust: expiredTrust.trust, now: NOW })).rejects.toThrow("outside its validity window");
+
+    const revokedTrust = await makeArtifacts();
+    revokedTrust.trust.revokedAt = "2029-12-01T00:00:00Z";
+    await expect(verifyProofBundle({ bundlePath: revokedTrust.directory, trust: revokedTrust.trust, now: NOW })).rejects.toThrow("has been revoked");
+  });
+});


### PR DESCRIPTION
## Scope
- adds the CC-1 Proving Ground verifier profile, separately trusted proof-bundle verification, and the sigil-verify CLI
- adds browser and Workers-safe root exports, Node-only bundle subpath, trust and tamper coverage, and immutable RC/final promotion workflows
- pins @sigilcore/warrant-core exactly to 0.1.1

## Verification
- npm ci
- npm run typecheck
- npm test, 62 passing
- npm run build
- npm run test:packed-cli
- npm pack --dry-run
- git diff --check

## Warrant surfaces
- Warrant Builder: no UI, signing, import, preview, download, deployment, migration, or round-trip change
- Manual Warrant: no grid, sample, or authoring-flow change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Proving Ground attestation verification and offline proof-bundle verification with trust-manifest validation and execution/audit modes.
  * Introduced the `sigil-verify` CLI and a Node-only verification surface, plus new public attestation/trust exports.
* **Documentation**
  * Added the Proving Ground attestation contract spec and an immutable release-candidate procedure; updated the README to point to the new documentation and verification surfaces.
* **Release Automation**
  * Added release-candidate and final promotion workflows with tag validation and checksum-verified immutable artifacts.
* **Tests**
  * Added browser-root compatibility checks, packaged-CLI smoke tests, workflow validation tests, and expanded end-to-end verifier coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->