### PR TITLE
Fix Proving Ground chain binding

### DIFF
--- a/ATTESTATION-CONTRACT.md
+++ b/ATTESTATION-CONTRACT.md
@@ -14,6 +14,7 @@ The current Sigil Sign signer emits an EdDSA JWT with these load-bearing claims:
 | `kid` | Present in both protected header and payload, with identical values. |
 | `intentHash` | Lowercase SHA-256 hex of the request `txCommit`. |
 | `policyHash` | Lowercase SHA-256 hex of the parsed Warrant policy object. |
+| `chainId` | Optional positive safe integer. When present, it must exactly match the optional top-level request `chainId`. |
 | `agentId`, `framework`, `provenance` | Signer metadata. These do not replace request binding. |
 
 The profile intentionally does not require `payload.intent`, `targetAddress`, or any EVM-only field. Tool-call approvals bind through the commitment below.
@@ -27,6 +28,8 @@ The proxy computes `txCommit` as lowercase SHA-256 hex over the UTF-8 bytes of `
 - Only JSON values are permitted. Cycles, `undefined`, functions, symbols, bigint values, sparse arrays, accessors, and non-finite numbers reject.
 
 The verifier recomputes this commitment from `request.json.intent`, requires it to equal `request.json.txCommit`, then requires `SHA-256(txCommit)` to equal the signed `intentHash`.
+
+`request.json.chainId` is an optional top-level execution-network binding. It is not part of `pg-commit-v1`, which continues to hash only `request.json.intent`. The JWT claim and request field must either both be absent or both be positive safe integers with exactly the same value. This preserves chain-free tool-call approvals while rejecting a request moved to a different chain.
 
 ## Verification modes
 

--- a/RELEASE-CANDIDATE.md
+++ b/RELEASE-CANDIDATE.md
@@ -1,9 +1,9 @@
 # Immutable Release Candidate Procedure
 
-Proposed Phase 2 candidate: `v0.2.0-rc.1`.
+Proposed Phase 2 candidate: `v0.2.0-rc.2`.
 
-The candidate is a GitHub Release only. Do not publish this verifier to npm. The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. After the Phase 6 real-token golden tests pass, create `v0.2.0` on the exact `v0.2.0-rc.1` commit. The promotion workflow downloads the RC tarball and checksum, verifies the checksum, and attaches those exact unchanged artifacts to the final release. Any code or artifact change requires `v0.2.0-rc.2`. Neither workflow overwrites an existing release.
+The candidate is a GitHub Release only. Do not publish this verifier to npm. The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. After the Phase 6 real-token golden tests pass, create `v0.2.0` on the exact `v0.2.0-rc.2` commit. The promotion workflow downloads the RC tarball and checksum, verifies the checksum, and attaches those exact unchanged artifacts to the final release. Any code or artifact change requires a new immutable release-candidate version. Neither workflow overwrites an existing release.
 
-The release workflow prepares `sigil-attestations-0.2.0-rc.1.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Consumers install the verified tarball with `npm install ./sigil-attestations-0.2.0-rc.1.tgz` after checking the published checksum. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
+The release workflow prepares `sigil-attestations-0.2.0-rc.2.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Consumers install the verified tarball with `npm install ./sigil-attestations-0.2.0-rc.2.tgz` after checking the published checksum. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
 
 The phase boundary prohibits tagging, publishing, or creating a release in this worktree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sigil-attestations",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sigil-attestations",
-      "version": "0.2.0-rc.1",
+      "version": "0.2.0-rc.2",
       "dependencies": {
         "@sigilcore/warrant-core": "0.1.1",
         "jose": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigil-attestations",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0-rc.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -127,7 +127,13 @@ export const verifyProofBundle = async (options: VerifyBundleOptions): Promise<V
   const attestation = await verifyProvingGroundAttestation(jwt, {
     trust,
     jwks,
-    request: { intent: request.intent, txCommit: request.txCommit },
+    request: {
+      intent: request.intent,
+      txCommit: request.txCommit,
+      ...(Object.prototype.hasOwnProperty.call(request, "chainId")
+        ? { chainId: request.chainId as number }
+        : {}),
+    },
     mode: options.mode,
     now,
   });

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -150,6 +150,25 @@ const validateAttestationClaims = (
   return { issuer: verifiedIssuer, payloadKid, exp, iat, authorizationExpired, policyHash, intentHash };
 };
 
+const verifyRequestCommitment = async (
+  request: ProvingGroundVerificationOptions["request"],
+  signedIntentHash: string
+): Promise<ProvingGroundVerificationResult["commitment"]> => {
+  if (!HEX_64.test(request.txCommit)) {
+    throw new InvalidPayloadError("request txCommit must be lowercase SHA-256 hex");
+  }
+  const adapter = webCryptoAdapter();
+  const recomputedCommit = await hashPgCommitV1(adapter, request.intent as never);
+  if (recomputedCommit !== request.txCommit) {
+    throw new InvalidPayloadError("request txCommit does not match pg-commit-v1 intent");
+  }
+  const recomputedIntentHash = hexFromBytes(await adapter.sha256(new TextEncoder().encode(request.txCommit)));
+  if (recomputedIntentHash !== signedIntentHash) {
+    throw new InvalidPayloadError("intentHash does not bind the request txCommit");
+  }
+  return { txCommit: recomputedCommit, intentHash: recomputedIntentHash };
+};
+
 /** Verify the CC-1 profile without changing the legacy strict verifier. */
 export const verifyProvingGroundAttestation = async (
   jwt: string,
@@ -167,12 +186,7 @@ export const verifyProvingGroundAttestation = async (
   const payload = decodeJwt(jwt) as Record<string, unknown>;
   const claims = validateAttestationClaims(payload, trust.issuer, trust.audience, headerKid, mode, now);
   const chainId = validateMatchingChainId(payload, options.request);
-  if (!HEX_64.test(options.request.txCommit)) throw new InvalidPayloadError("request txCommit must be lowercase SHA-256 hex");
-  const adapter = webCryptoAdapter();
-  const recomputedCommit = await hashPgCommitV1(adapter, options.request.intent as never);
-  if (recomputedCommit !== options.request.txCommit) throw new InvalidPayloadError("request txCommit does not match pg-commit-v1 intent");
-  const recomputedIntentHash = hexFromBytes(await adapter.sha256(new TextEncoder().encode(options.request.txCommit)));
-  if (recomputedIntentHash !== claims.intentHash) throw new InvalidPayloadError("intentHash does not bind the request txCommit");
+  const commitment = await verifyRequestCommitment(options.request, claims.intentHash);
   const verifiedClaims: ProvingGroundVerificationResult["claims"] = {
     iss: claims.issuer,
     aud: trust.audience,
@@ -186,6 +200,6 @@ export const verifyProvingGroundAttestation = async (
   return {
     mode, authorizationExpired: claims.authorizationExpired, protectedHeader: header as Record<string, unknown>,
     claims: verifiedClaims,
-    commitment: { txCommit: recomputedCommit, intentHash: recomputedIntentHash },
+    commitment,
   };
 };

--- a/src/proving-ground.ts
+++ b/src/proving-ground.ts
@@ -15,6 +15,34 @@ const requireInteger = (value: unknown, name: string): number => {
   return value as number;
 };
 
+interface OptionalChainId {
+  present: boolean;
+  value?: number;
+}
+
+const readOptionalChainId = (source: { chainId?: unknown }, name: string): OptionalChainId => {
+  if (!Object.prototype.hasOwnProperty.call(source, "chainId")) return { present: false };
+  if (!Number.isSafeInteger(source.chainId) || (source.chainId as number) <= 0) {
+    throw new InvalidPayloadError(`${name} must be a positive safe integer`);
+  }
+  return { present: true, value: source.chainId as number };
+};
+
+const validateMatchingChainId = (
+  payload: Record<string, unknown>,
+  request: ProvingGroundVerificationOptions["request"]
+): number | undefined => {
+  const signedChainId = readOptionalChainId(payload, "JWT chainId");
+  const requestChainId = readOptionalChainId(request, "request chainId");
+  if (
+    signedChainId.present !== requestChainId.present ||
+    (signedChainId.present && signedChainId.value !== requestChainId.value)
+  ) {
+    throw new InvalidPayloadError("JWT chainId must exactly match request chainId");
+  }
+  return signedChainId.value;
+};
+
 const resolveVerificationMode = (value: unknown): VerificationMode => {
   if (value === undefined) return "execution";
   if (value === "execution" || value === "audit") return value;
@@ -138,15 +166,26 @@ export const verifyProvingGroundAttestation = async (
   await verifyJwtSignature(jwt, options.jwks);
   const payload = decodeJwt(jwt) as Record<string, unknown>;
   const claims = validateAttestationClaims(payload, trust.issuer, trust.audience, headerKid, mode, now);
+  const chainId = validateMatchingChainId(payload, options.request);
   if (!HEX_64.test(options.request.txCommit)) throw new InvalidPayloadError("request txCommit must be lowercase SHA-256 hex");
   const adapter = webCryptoAdapter();
   const recomputedCommit = await hashPgCommitV1(adapter, options.request.intent as never);
   if (recomputedCommit !== options.request.txCommit) throw new InvalidPayloadError("request txCommit does not match pg-commit-v1 intent");
   const recomputedIntentHash = hexFromBytes(await adapter.sha256(new TextEncoder().encode(options.request.txCommit)));
   if (recomputedIntentHash !== claims.intentHash) throw new InvalidPayloadError("intentHash does not bind the request txCommit");
+  const verifiedClaims: ProvingGroundVerificationResult["claims"] = {
+    iss: claims.issuer,
+    aud: trust.audience,
+    exp: claims.exp,
+    iat: claims.iat,
+    kid: claims.payloadKid,
+    intentHash: claims.intentHash,
+    policyHash: claims.policyHash,
+  };
+  if (chainId !== undefined) verifiedClaims.chainId = chainId;
   return {
     mode, authorizationExpired: claims.authorizationExpired, protectedHeader: header as Record<string, unknown>,
-    claims: { iss: claims.issuer, aud: trust.audience, exp: claims.exp, iat: claims.iat, kid: claims.payloadKid, intentHash: claims.intentHash, policyHash: claims.policyHash },
+    claims: verifiedClaims,
     commitment: { txCommit: recomputedCommit, intentHash: recomputedIntentHash },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export interface SigilTrustManifestV1 {
 
 export interface ProvingGroundVerificationOptions {
   trust: SigilTrustManifestV1;
-  request: { intent: unknown; txCommit: string };
+  request: { intent: unknown; txCommit: string; chainId?: number };
   jwks: unknown;
   mode?: VerificationMode;
   now?: Date;
@@ -79,7 +79,16 @@ export interface ProvingGroundVerificationResult {
   mode: VerificationMode;
   authorizationExpired: boolean;
   protectedHeader: Record<string, unknown>;
-  claims: { iss: string; aud: string; exp: number; iat: number; kid: string; intentHash: string; policyHash: string };
+  claims: {
+    iss: string;
+    aud: string;
+    exp: number;
+    iat: number;
+    kid: string;
+    intentHash: string;
+    policyHash: string;
+    chainId?: number;
+  };
   commitment: { txCommit: string; intentHash: string };
 }
 

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -16,7 +16,7 @@ const directories: string[] = [];
 const NOW = new Date("2030-01-01T00:00:00Z");
 const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
 const WARRANTY = "version: 2.1.0\n\n## tool_calls\nallowed: web_fetch\n";
-const INTENT = { action: "web_fetch", chainId: 1, url: "https://docs.sigilcore.com/getting-started", metadata: { job_type: "documentation" } };
+const INTENT = { action: "web_fetch", url: "https://docs.sigilcore.com/getting-started", metadata: { job_type: "documentation" } };
 
 afterEach(async () => {
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
@@ -25,7 +25,7 @@ afterEach(async () => {
 const PQC_KEY = { kty: "ML-DSA", alg: "ML-DSA-65", kid: "synthetic-pqc", publicKey: "AQIDBA", use: "sig" };
 
 // skipcq: JS-R1005 - The fixture creates one cryptographically linked offline bundle so every negative test mutates a consistent baseline.
-const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string } = {}) => {
+const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audience?: string; payloadKid?: string; expiresAt?: number; warranty?: string; canonical?: unknown; jwks?: unknown; pqcKeys?: unknown; responseAttestation?: string; chainId?: number } = {}) => {
   const signer = await generateKeyPair("EdDSA");
   const operator = await generateKeyPair("EdDSA");
   const signerJwk = await exportJWK(signer.publicKey);
@@ -35,10 +35,12 @@ const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audien
   const policyHash = await hashPolicy(createNodeCryptoAdapter(), policy);
   const txCommit = await hashPgCommitV1(createNodeCryptoAdapter(), INTENT);
   const intentHash = createHash("sha256").update(txCommit, "utf8").digest("hex");
-  const jwt = await new SignJWT({
+  const jwtClaims: Record<string, unknown> = {
     aud: overrides.audience ?? "sigil-sign", kid: overrides.payloadKid ?? kid, intentHash, policyHash: overrides.attestationPolicyHash ?? policyHash,
     agentId: "synthetic-agent", framework: "synthetic", provenance: "agent",
-  })
+  };
+  if (overrides.chainId !== undefined) jwtClaims.chainId = overrides.chainId;
+  const jwt = await new SignJWT(jwtClaims)
     .setProtectedHeader({ alg: "EdDSA", kid })
     .setIssuer("sigil-core")
     .setIssuedAt(NOW_SECONDS - 10)
@@ -61,7 +63,11 @@ const makeArtifacts = async (overrides: { attestationPolicyHash?: string; audien
     writeFile(join(directory, "warranty.md"), warranty),
     writeFile(join(directory, "operator-public-key.json"), JSON.stringify(operatorJwk)),
     writeFile(join(directory, "attestation.jwt"), jwt),
-    writeFile(join(directory, "request.json"), JSON.stringify({ intent: INTENT, txCommit })),
+    writeFile(join(directory, "request.json"), JSON.stringify({
+      intent: INTENT,
+      txCommit,
+      ...(overrides.chainId === undefined ? {} : { chainId: overrides.chainId }),
+    })),
     writeFile(join(directory, "response.json"), JSON.stringify({ intent_attestation: overrides.responseAttestation ?? jwt })),
     writeFile(join(directory, "jwks.json"), JSON.stringify(overrides.jwks ?? { keys: [{ ...signerJwk, kid, alg: "EdDSA", use: "sig" }] })),
     writeFile(join(directory, "pqc-keys.json"), JSON.stringify(overrides.pqcKeys ?? { keys: [PQC_KEY] })),
@@ -81,6 +87,14 @@ describe("Proving Ground verifier profile", () => {
     const result = await verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW });
     expect(result.operatorSignatureValid).toBe(true);
     expect(result.authorizationExpired).toBe(false);
+    expect(result.commitment.txCommit).toBe(artifact.txCommit);
+    expect(result.claims.chainId).toBeUndefined();
+  });
+
+  it("proves the signed chain while leaving pg-commit-v1 bound only to intent", async () => {
+    const artifact = await makeArtifacts({ chainId: 1 });
+    const result = await verifyProofBundle({ bundlePath: artifact.directory, trust: artifact.trust, now: NOW });
+    expect(result.claims.chainId).toBe(1);
     expect(result.commitment.txCommit).toBe(artifact.txCommit);
   });
 
@@ -166,16 +180,36 @@ describe("Proving Ground verifier profile", () => {
   });
 
   it("rejects a request that differs only by chain", async () => {
-    const artifact = await makeArtifacts();
+    const artifact = await makeArtifacts({ chainId: 1 });
     await writeFile(join(artifact.directory, "request.json"), JSON.stringify({
-      intent: { ...INTENT, chainId: 8453 },
+      intent: INTENT,
       txCommit: artifact.txCommit,
+      chainId: 8453,
     }));
     await expect(verifyProofBundle({
       bundlePath: artifact.directory,
       trust: artifact.trust,
       now: NOW,
-    })).rejects.toThrow("does not match pg-commit-v1 intent");
+    })).rejects.toThrow("JWT chainId must exactly match request chainId");
+  });
+
+  it.each([
+    ["JWT chainId", { signed: 0, requested: 0 }, "JWT chainId must be a positive safe integer"],
+    ["JWT chainId", { signed: Number.MAX_SAFE_INTEGER + 1, requested: 1 }, "JWT chainId must be a positive safe integer"],
+    ["request chainId", { signed: 1, requested: -1 }, "request chainId must be a positive safe integer"],
+    ["request chainId", { signed: 1, requested: 1.5 }, "request chainId must be a positive safe integer"],
+    ["missing request chainId", { signed: 1, requested: undefined }, "JWT chainId must exactly match request chainId"],
+    ["missing JWT chainId", { signed: undefined, requested: 1 }, "JWT chainId must exactly match request chainId"],
+  ])("rejects invalid or unmatched %s", async (_label, chainIds, message) => {
+    const artifact = await makeArtifacts({ chainId: chainIds.signed });
+    const request: Record<string, unknown> = { intent: INTENT, txCommit: artifact.txCommit };
+    if (chainIds.requested !== undefined) request.chainId = chainIds.requested;
+    await writeFile(join(artifact.directory, "request.json"), JSON.stringify(request));
+    await expect(verifyProofBundle({
+      bundlePath: artifact.directory,
+      trust: artifact.trust,
+      now: NOW,
+    })).rejects.toThrow(message);
   });
 
   it("rejects a changed commitment, policy hash, or JWT signature", async () => {


### PR DESCRIPTION
## Summary

- bind optional signed JWT `chainId` to the top-level request `chainId`
- keep `pg-commit-v1` scoped to the request intent
- preserve chain-free tool-call verification
- publish the correction as immutable candidate `v0.2.0-rc.2`

## Validation

- `npm run typecheck`
- `npm test` (78 tests)
- `npm run build`
- `npm run test:packed-cli`
- `git diff --check`

## Authoring surfaces

Warrant Builder: no impact. This change verifies execution-network binding in offline proof bundles and does not change Warrant authoring, parsing, signing, import, or round-trip behavior.

Manual Warrant: no impact. The Warrant source and operator-signature contract remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `chainId` binding for attestation verification across the signed payload and verification request.
  * When present and valid, `chainId` is included in verified claims; strict validation now rejects missing, mismatched, or non-safe-integer values.
  * Request commitment verification was strengthened to ensure `txCommit` correctly derives and matches the signed intent hash.

* **Release**
  * Bumped the package to `0.2.0-rc.2` and updated release-candidate procedure/artifact naming to match.

* **Documentation**
  * Updated verifier attestation contract guidance: `chainId` is an execution-network binding and is not part of the `pg-commit-v1` intent commitment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->