### PR TITLE
chore: pin warrant core canonicalizer to 0.2.1

### DIFF
--- a/ATTESTATION-CONTRACT.md
+++ b/ATTESTATION-CONTRACT.md
@@ -21,7 +21,7 @@ The profile intentionally does not require `payload.intent`, `targetAddress`, or
 
 ## Request binding: `pg-commit-v1`
 
-The proxy computes `txCommit` as lowercase SHA-256 hex over the UTF-8 bytes of `canonicalizePgCommitV1(intent)` from `@sigilcore/warrant-core@0.2.0`.
+The proxy computes `txCommit` as lowercase SHA-256 hex over the UTF-8 bytes of `canonicalizePgCommitV1(intent)` from `@sigilcore/warrant-core@0.2.1`.
 
 - Object keys sort by ECMAScript UTF-16 code-unit order.
 - Array order remains unchanged.
@@ -78,14 +78,14 @@ pqc-keys.json
 VERIFY.md
 ```
 
-`response.json.intent_attestation` must byte-match `attestation.jwt`. `warranty.md` must carry a final `## signature` block. The verifier checks that signature over the unsigned Warrant bytes, parses the Warrant with `@sigilcore/warrant-core@0.2.0`, and derives its hash independently.
+`response.json.intent_attestation` must byte-match `attestation.jwt`. `warranty.md` must carry a final `## signature` block. The verifier checks that signature over the unsigned Warrant bytes, parses the Warrant with `@sigilcore/warrant-core@0.2.1`, and derives its hash independently.
 
 `policy.canonical.json` uses this versioned envelope. Metadata never enters the policy hash:
 
 ```json
 {
   "schema": "sigil-policy-canonical/v1",
-  "canonicalizer": "@sigilcore/warrant-core@0.2.0",
+  "canonicalizer": "@sigilcore/warrant-core@0.2.1",
   "policy": { "version": "2.1.0" }
 }
 ```
@@ -106,7 +106,7 @@ sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit 
 
 ### Warrant Builder: no user-interface or signing change in Phase 2
 
-The verifier consumes a downloaded signed Warrant through the exact `@sigilcore/warrant-core@0.2.0` parser and canonicalizer. It adds no Builder field, import rule, signing path, preview behavior, download format, deployment behavior, migration, or round-trip change. The release gate is the already-required Phase 1 Builder regression evidence plus this verifier's derived-policy test. Any policy hash difference between Builder output and the shared core blocks fixture release.
+The verifier consumes a downloaded signed Warrant through the exact `@sigilcore/warrant-core@0.2.1` parser and canonicalizer. It adds no Builder field, import rule, signing path, preview behavior, download format, deployment behavior, migration, or round-trip change. The release gate is the already-required Phase 1 Builder regression evidence plus this verifier's derived-policy test. Any policy hash difference between Builder output and the shared core blocks fixture release.
 
 ### Manual Warrant: no grid, sample, or authoring-flow change in Phase 2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sigil-attestations",
       "version": "0.2.0-rc.2",
       "dependencies": {
-        "@sigilcore/warrant-core": "0.2.0",
+        "@sigilcore/warrant-core": "0.2.1",
         "jose": "^5.0.0"
       },
       "bin": {
@@ -769,9 +769,9 @@
       ]
     },
     "node_modules/@sigilcore/warrant-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sigilcore/warrant-core/-/warrant-core-0.2.0.tgz",
-      "integrity": "sha512-bn1M/xQL6kFzw/rJNYvrzj+cJJepGxaktZaaZA/uIvglRCkPe8yem7ZnOyScHkrQLTWA3Mnp8GSN7oPoqgpbmQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sigilcore/warrant-core/-/warrant-core-0.2.1.tgz",
+      "integrity": "sha512-1q2H80vewATLciWUoJLV+4v6ApqPrLfsw9kUBcK37eMMfZzdIetf8jQzcGw1wkE+6nbdO/j2Hb+4HeK/yh8SBw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:packed-cli": "node scripts/test-packed-cli.mjs"
   },
   "dependencies": {
-    "@sigilcore/warrant-core": "0.2.0",
+    "@sigilcore/warrant-core": "0.2.1",
     "jose": "^5.0.0"
   },
   "devDependencies": {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -27,7 +27,7 @@ const requiredFiles = [
 ] as const;
 
 export const CANONICAL_POLICY_ENVELOPE_SCHEMA = "sigil-policy-canonical/v1";
-export const CANONICALIZER_VERSION = "@sigilcore/warrant-core@0.2.0";
+export const CANONICALIZER_VERSION = "@sigilcore/warrant-core@0.2.1";
 
 const readUtf8 = async (bundlePath: string, name: string): Promise<string> => {
   try {

--- a/tests/proving-ground.test.ts
+++ b/tests/proving-ground.test.ts
@@ -276,13 +276,13 @@ describe("Proving Ground verifier profile", () => {
   });
 
   it("binds the response, canonicalizer, PQC snapshot, and trust lifecycle", async () => {
-    expect(CANONICALIZER_VERSION).toBe("@sigilcore/warrant-core@0.2.0");
+    expect(CANONICALIZER_VERSION).toBe("@sigilcore/warrant-core@0.2.1");
     const responseMismatch = await makeArtifacts({ responseAttestation: "not-the-attestation" });
     await expect(verifyProofBundle({ bundlePath: responseMismatch.directory, trust: responseMismatch.trust, now: NOW })).rejects.toThrow("response.json intent_attestation");
 
     const canonicalizerMismatch = await makeArtifacts();
     const canonical = JSON.parse(await readFile(join(canonicalizerMismatch.directory, "policy.canonical.json"), "utf8"));
-    canonical.canonicalizer = "@sigilcore/warrant-core@0.1.1";
+    canonical.canonicalizer = "@sigilcore/warrant-core@0.2.0";
     await writeFile(join(canonicalizerMismatch.directory, "policy.canonical.json"), JSON.stringify(canonical));
     await expect(verifyProofBundle({ bundlePath: canonicalizerMismatch.directory, trust: canonicalizerMismatch.trust, now: NOW })).rejects.toThrow("unsupported canonicalizer envelope");
 


### PR DESCRIPTION
## Summary

- pin `@sigilcore/warrant-core` to immutable `0.2.1` and its published lockfile integrity
- update all proof-bundle canonicalizer identifiers and attestation-contract references
- reject the immediately prior `0.2.0` canonicalizer envelope

## Verification

- `npm ci`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:packed-cli`
- scoped CodeRabbit review completed

## Review note

CodeRabbit noted the package’s pre-existing missing `license` metadata. This narrow dependency pin does not change package metadata and the repository already ships `LICENSE`, so no unrelated change is included.