### PR TITLE
chore: prepare sigil-attestations 0.2.1-rc.1

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -94,7 +94,6 @@ jobs:
       - name: Require the npm trusted-publishing runtime
         run: |
           node --input-type=module -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) process.exit(1)"
-          npm install --global npm@11.5.1
           node --input-type=module -e "const { execFileSync } = await import('node:child_process'); const [major, minor, patch] = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)"
       - name: Refuse an existing immutable npm version
         env:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -73,3 +73,44 @@ jobs:
           gh release create "$GITHUB_REF_NAME" sigil-attestations-*.tgz
           sigil-attestations-*.tgz.sha256 --title "$GITHUB_REF_NAME"
           --notes-file RELEASE-CANDIDATE.md --verify-tag
+
+  publish:
+    needs: [build, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download tested candidate package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: verifier-candidate-${{ github.ref_name }}
+          path: .
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Require the npm trusted-publishing runtime
+        run: |
+          node --input-type=module -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) process.exit(1)"
+          npm install --global npm@11.5.1
+          node --input-type=module -e "const { execFileSync } = await import('node:child_process'); const [major, minor, patch] = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim().split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)"
+      - name: Refuse an existing immutable npm version
+        env:
+          PACKAGE_VERSION: ${{ github.ref_name }}
+        run: |
+          package_version="${PACKAGE_VERSION#v}"
+          if npm view "sigil-attestations@${package_version}" version --json > /tmp/npm-existing.json 2> /tmp/npm-view.err; then
+            echo "npm version already exists: sigil-attestations@${package_version}"
+            exit 1
+          fi
+          if ! grep -Eq "E404|404 Not Found" /tmp/npm-view.err; then
+            cat /tmp/npm-view.err
+            exit 1
+          fi
+      - name: Publish prerelease with npm trusted publishing and provenance
+        run: |
+          package_file="$(find . -maxdepth 1 -name 'sigil-attestations-*.tgz' -print -quit)"
+          test -n "$package_file"
+          npm publish "$package_file" --access public --tag next --provenance

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Warrant Builder and Manual Warrant receive no UI, authoring, signing, import, pr
 
 ## Proving Ground verifier release
 
+The CC-1 raw-proof verifier is available as the immutable npm prerelease `sigil-attestations@0.2.1-rc.1`. Install the exact version so prerelease updates cannot move the dependency implicitly:
+
+```sh
+npm install --save-exact sigil-attestations@0.2.1-rc.1
+```
+
+This prerelease uses the npm `next` dist-tag and carries registry provenance from the repository's trusted GitHub Actions publisher. It is not the stable `latest` release.
+
+### Historical Proving Ground release
+
 The final Proving Ground verifier is the GitHub Release [`v0.2.0`](https://github.com/Sigil-Core/sigil-attestations/releases/tag/v0.2.0). It promotes the unchanged `v0.2.0-rc.2` candidate at commit [`568a327224477e7416688c3cfdb50bbac4950bfb`](https://github.com/Sigil-Core/sigil-attestations/commit/568a327224477e7416688c3cfdb50bbac4950bfb). This launch uses GitHub Release artifacts only. It does not publish the verifier to npm.
 
 The final release retains the immutable candidate artifact name and bytes:

--- a/RELEASE-CANDIDATE.md
+++ b/RELEASE-CANDIDATE.md
@@ -1,9 +1,9 @@
 # Immutable Release Candidate Procedure
 
-Proposed Phase 2 candidate: `v0.2.0-rc.2`.
+Proposed CC-1 verifier candidate: `v0.2.1-rc.1`.
 
-The candidate is a GitHub Release only. Do not publish this verifier to npm. The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. After the Phase 6 real-token golden tests pass, create `v0.2.0` on the exact `v0.2.0-rc.2` commit. The promotion workflow downloads the RC tarball and checksum, verifies the checksum, and attaches those exact unchanged artifacts to the final release. Any code or artifact change requires a new immutable release-candidate version. Neither workflow overwrites an existing release.
+The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. It attaches the tested tarball and checksum to the immutable GitHub Release, then publishes the same package as `sigil-attestations@0.2.1-rc.1` under the npm `next` dist-tag through npm trusted publishing with provenance. Any code or artifact change requires a new immutable release-candidate version. Neither GitHub nor npm permits overwriting this version.
 
-The release workflow prepares `sigil-attestations-0.2.0-rc.2.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Consumers install the verified tarball with `npm install ./sigil-attestations-0.2.0-rc.2.tgz` after checking the published checksum. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
+The release workflow prepares `sigil-attestations-0.2.1-rc.1.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Reproducible consumers install the exact registry version with `npm install --save-exact sigil-attestations@0.2.1-rc.1`. Tarball consumers may download the GitHub Release asset and verify its companion checksum first. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
 
-The phase boundary prohibits tagging, publishing, or creating a release in this worktree.
+Do not promote this candidate to stable `v0.2.1`. Historical-verifier work must use a later immutable candidate such as `v0.2.1-rc.2`.

--- a/RELEASE-CANDIDATE.md
+++ b/RELEASE-CANDIDATE.md
@@ -1,9 +1,9 @@
-# Immutable Release Candidate Procedure
+# Release Candidate Procedure
 
 Proposed CC-1 verifier candidate: `v0.2.1-rc.1`.
 
-The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. It attaches the tested tarball and checksum to the immutable GitHub Release, then publishes the same package as `sigil-attestations@0.2.1-rc.1` under the npm `next` dist-tag through npm trusted publishing with provenance. Any code or artifact change requires a new immutable release-candidate version. Neither GitHub nor npm permits overwriting this version.
+The RC workflow runs the full test suite, builds, packs, installs the tarball into an isolated temporary consumer, and invokes `sigil-verify --help`. It creates the matching GitHub Release with `--verify-tag`, attaches the tested tarball and checksum, then publishes the same package as `sigil-attestations@0.2.1-rc.1` under the npm `next` dist-tag through npm trusted publishing with provenance. The release command fails instead of replacing an existing release for that tag, but the workflow does not make GitHub release assets immutable. Consumers must verify the checksum and attestation. npm package versions cannot be overwritten after publication, so any code or artifact change requires a new release-candidate version.
 
-The release workflow prepares `sigil-attestations-0.2.1-rc.1.tgz` and its SHA-256 checksum, then attaches both to the matching immutable GitHub Release. Reproducible consumers install the exact registry version with `npm install --save-exact sigil-attestations@0.2.1-rc.1`. Tarball consumers may download the GitHub Release asset and verify its companion checksum first. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
+The release workflow prepares `sigil-attestations-0.2.1-rc.1.tgz` and its SHA-256 checksum, then attaches both to the matching GitHub Release. Reproducible consumers install the exact registry version with `npm install --save-exact sigil-attestations@0.2.1-rc.1`. Tarball consumers may download the GitHub Release asset and verify its companion checksum first. Use `sigil-verify --bundle ./proof-bundle --trust ./sigil-trust.v1.json --mode audit` after installation.
 
 Do not promote this candidate to stable `v0.2.1`. Historical-verifier work must use a later immutable candidate such as `v0.2.1-rc.2`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "sigil-attestations",
       "version": "0.2.1-rc.1",
+      "license": "MIT",
       "dependencies": {
         "@sigilcore/warrant-core": "0.2.3",
         "jose": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sigil-attestations",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sigil-attestations",
-      "version": "0.2.0-rc.2",
+      "version": "0.2.1-rc.1",
       "dependencies": {
         "@sigilcore/warrant-core": "0.2.3",
         "jose": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "sigil-attestations",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.1-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sigil-Core/sigil-attestations.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "tag": "next"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sigil-attestations",
   "version": "0.2.1-rc.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Sigil-Core/sigil-attestations.git"

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -36,4 +36,15 @@ describe("final promotion workflow", () => {
     expect(workflow).toContain("subject-path:");
     expect(workflow).not.toContain('gh release view "$GITHUB_REF_NAME"');
   });
+
+  it("publishes prereleases through npm trusted publishing without a long-lived token", async () => {
+    const workflow = await readFile(releaseWorkflowPath, "utf8");
+    expect(workflow).toContain("publish:\n    needs: [build, release]");
+    expect(workflow).toContain("registry-url: https://registry.npmjs.org");
+    expect(workflow).toContain("npm install --global npm@11.5.1");
+    expect(workflow).toContain("Refuse an existing immutable npm version");
+    expect(workflow).toContain('npm publish "$package_file" --access public --tag next --provenance');
+    expect(workflow).not.toContain("NODE_AUTH_TOKEN");
+    expect(workflow).not.toContain("NPM_TOKEN");
+  });
 });

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -39,12 +39,17 @@ describe("final promotion workflow", () => {
 
   it("publishes prereleases through npm trusted publishing without a long-lived token", async () => {
     const workflow = await readFile(releaseWorkflowPath, "utf8");
-    expect(workflow).toContain("publish:\n    needs: [build, release]");
+    expect(workflow).toContain(
+      "publish:\n    needs: [build, release]\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n      id-token: write",
+    );
     expect(workflow).toContain("registry-url: https://registry.npmjs.org");
-    expect(workflow).toContain("npm install --global npm@11.5.1");
+    expect(workflow).toContain("execFileSync('npm', ['--version']");
+    expect(workflow).toContain("minor < 5 || (minor === 5 && patch < 1)");
+    expect(workflow).not.toContain("npm install --global");
     expect(workflow).toContain("Refuse an existing immutable npm version");
     expect(workflow).toContain('npm publish "$package_file" --access public --tag next --provenance');
-    expect(workflow).not.toContain("NODE_AUTH_TOKEN");
-    expect(workflow).not.toContain("NPM_TOKEN");
+    for (const credentialVariable of ["NODE_AUTH_TOKEN", "NPM_TOKEN"]) {
+      expect(workflow).not.toContain(credentialVariable);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- bump `sigil-attestations` and its lockfile to exact version `0.2.1-rc.1`
- publish RC tags to npm under `next` with OIDC trusted publishing and provenance
- retain the tested tarball GitHub Release and add workflow regression coverage
- document exact prerelease installation and prohibit stable promotion

## Verification

- `npm ci --ignore-scripts`
- `npm test` (95 tests)
- `npm run typecheck`
- `npm run build`
- `npm run test:packed-cli`
- `npm pack --json` plus tarball manifest inspection
- release workflow YAML parse and exact package/lock alignment
- npm 11.5.1 missing-version guard reproduction
- independent exact-diff review: verified, zero findings

## Release gate

Do not push `v0.2.1-rc.1` until npm authorizes the first publication of the unclaimed `sigil-attestations` name. The repository has no npm token secret and the local npm session is unauthenticated. Subsequent candidates use the trusted publisher bound to `Sigil-Core/sigil-attestations` and `release-rc.yml`. No stable tag or `latest` publication is in scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Published prerelease version `0.2.1-rc.1` to npm using the `next` tag.
  * Added trusted publishing and provenance metadata.
  * Prevented overwriting an existing package version.

* **Documentation**
  * Added instructions for installing the exact prerelease version.
  * Updated release-candidate guidance, verification steps, and checksum instructions.

* **Tests**
  * Added coverage confirming prerelease publishing and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->