### PR TITLE
chore: allowlist dependency install scripts ahead of npm v12 defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,9 @@
     "typescript": "^5.0.0",
     "vitest": "^2.0.0",
     "warrant-core-0-2-1-fixture": "npm:@sigilcore/warrant-core@0.2.1"
+  },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": true
   }
 }


### PR DESCRIPTION
npm v12 disables dependency lifecycle scripts by default (https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/). This adds the allowScripts allowlist to package.json covering the dependencies that need install scripts: esbuild, fsevents.

Entries are name-only rather than version-pinned so Dependabot bumps do not silently strand a stale pin; the lockfile still pins exact versions and integrity hashes. No git or remote-URL dependencies exist in this repo, so the new allow-git/allow-remote defaults need no action.

Verification: npm ci --strict-allow-scripts passes from a clean node_modules (simulates npm v12 enforcement), and npm approve-scripts --allow-scripts-pending reports no unreviewed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)