### PR TITLE
chore(coderabbit): disable auto_review per house review policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 
 reviews:
   auto_review:
-    enabled: true
+    enabled: false
 
   path_instructions:
     # Review finding rejected 2026-07-29 (raised HIGH on sigil-vault and sigil-command).


### PR DESCRIPTION
## Summary

Sets `reviews.auto_review.enabled: false` in `.coderabbit.yaml`. Everything else in the file (Dependabot path instructions, path filters, the `knowledge_base.code_guidelines` block) is unchanged.

## Why

The house rule ("Code review passes locally before the PR; never stack automated PR reviewers") requires per-repo CodeRabbit auto-review to be off. The local `handoff-review` pre-commit gate is THE review; auto-review on open PRs only stacks a duplicate reviewer and delays deployment. This repo was the remaining one with it enabled, flagged by pr-preflight-check on July 31, 2026 while opening PR #17.

## Review

Local review gate (`handoff-review`) ran clean: PASS. CodeRabbit CLI was rate-limited (org spending cap), DeepSource cannot review uncommitted changes, so the chain completed on the Claude reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)