### PR TITLE
Classify immutable RC releases as prereleases

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -79,7 +79,7 @@ jobs:
         run: >-
           gh release create "$GITHUB_REF_NAME" sigil-attestations-*.tgz
           sigil-attestations-*.tgz.sha256 --title "$GITHUB_REF_NAME"
-          --notes-file RELEASE-CANDIDATE.md --verify-tag
+          --notes-file RELEASE-CANDIDATE.md --verify-tag --prerelease
 
   publish:
     needs: [build, release]

--- a/tests/promote-final-workflow.test.ts
+++ b/tests/promote-final-workflow.test.ts
@@ -41,6 +41,7 @@ describe("final promotion workflow", () => {
     expect(workflow).toContain('= "$GITHUB_SHA"');
     expect(workflow).toContain("actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6");
     expect(workflow).toContain("subject-path:");
+    expect(workflow).toContain("--verify-tag --prerelease");
     expect(workflow).not.toContain('gh release view "$GITHUB_REF_NAME"');
   });
 


### PR DESCRIPTION
## Summary

- add `--prerelease` to the immutable RC GitHub Release command
- enforce the classification in the workflow contract test

The already-published immutable `v0.2.1-rc.2` release was also marked prerelease through editable GitHub release metadata. Its tag and assets remain immutable.

## Verification

- Node 22.22.0 and npm 11.12.1
- `npm run typecheck`
- `npm test` (95 tests)
- `npm run build`
- `npm run test:packed-cli`
- local `handoff-review`: PASS