### PR TITLE
chore: add Greptile config with auto-review kill switch

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,7 @@
+{
+  "skipReview": "AUTOMATIC",
+  "triggerOnUpdates": false,
+  "context": {
+    "repos": ["Sigil-Core/sigil-sign"]
+  }
+}


### PR DESCRIPTION
## What

Adds `greptile.json` at repo root:

```json
{
  "skipReview": "AUTOMATIC",
  "triggerOnUpdates": false,
  "context": {
    "repos": ["Sigil-Core/sigil-sign"]
  }
}
```

- `skipReview: "AUTOMATIC"` is the auto-review kill switch required by the house no-stacking rule (CodeRabbit and DeepSource are not interchangeable; no automated reviewer gates a Sigil default branch). It suppresses automatic Greptile reviews; manual `@greptile` triggers still work.
- `triggerOnUpdates: false` is set explicitly because an org dashboard setting currently overrides its documented default of `false`.
- `context.repos` points at `Sigil-Core/sigil-sign`, sigil-attestations's cross-repo contract counterpart per the contract inventory, so Greptile's repository graph can reason about the shared contract surface.

Config-only change (`.json`), not code-bearing, so no DeepSource stage 2 applies.

## Why

Vernon approved this Greptile rollout on 2026-08-08 as part of bringing repos that don't receive `agents-global.md` up to the same review-config baseline as the repos that do.

Verified before opening this PR: no pre-existing `greptile.json` or `.greptile/` directory in this repository at the branch point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
