### PR TITLE
fix(deps): bump nanoid to 3.3.18 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,9 +1427,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the pre-existing Dependency audit failure on main: 1 high advisory, nanoid <3.3.17 (GHSA-2v37-7h3g-55p8, infinite loop with zero-size custom generators), dev-only transitive via vitest -> vite -> postcss. Lockfile-only in-range bump 3.3.16 -> 3.3.18 produced by npm@11.12.1 update nanoid. Validated: npm audit 0 vulns (full and production), typecheck/build/95 tests pass, lockfile stable under the CI-pinned npm 11.12.1 determinism check.