### PR TITLE
chore(review): turn on greptile auto-review

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,5 @@
 {
-  "skipReview": "AUTOMATIC",
-  "triggerOnUpdates": false,
+  "triggerOnUpdates": true,
   "context": {
     "repos": ["Sigil-Core/sigil-sign"]
   }


### PR DESCRIPTION
## What this changes

Restores Greptile as the **review of record**, per the v3 review flow in `rules-engineering.md`, adopted 2026-08-16.

This repository's `greptile.json` carried `skipReview: "AUTOMATIC"`. That key was correct under the July 21, 2026 policy, which put the whole review gate before the PR boundary. Under v3 it is wrong, and it fails silently: the hosted review never runs, no red check appears, and nothing reports a missing review.

| Key | Before | After |
| --- | --- | --- |
| `skipReview` | `"AUTOMATIC"` | removed |
| `triggerOnUpdates` | `false` | `true` |
| `context.repos` | unchanged | unchanged |

`triggerOnUpdates: true` is required by the v3 **final-head rule**: merge is blocked unless the review of record completed on the exact current PR head, so Greptile must re-review each pushed commit on an open PR.

`context.repos` matches the contract-paired repository table in `agents-global-canonical.md`. No pairing was added, removed, or invented.

## Auto-approve

Auto-approve stays off, permanently. Note where that control lives: `autoApprove` is documented as a `.greptile/config.json` field and is **not** in the `greptile.json` parameter list, so this file cannot pin it. Its documented default is `false`, and it is otherwise a dashboard toggle. "Off" is a dashboard fact to verify, not a repository fact this PR can assert.

## Schema source

https://www.greptile.com/docs/code-review/greptile-json-reference

Confirmed against primary documentation before writing: `triggerOnUpdates` (boolean, default `false`), `skipReview` (string, literal `"AUTOMATIC"`), `context.repos` (array of `owner/repo`). No key name was guessed.

## Review gates

Configuration-only change, no code. Stage 1 ran with `SIGIL_REVIEW_SKIP=1`. Stage 2 (DeepSource) has no code-bearing path in this diff.

This PR is also the **activation test** for v3 in this repository. Per `rules-engineering.md`, the config is not trusted until one test PR shows an update review completing on a pushed follow-up commit. Until that is observed, the `activation-pending` fallback governs this repository.
