### PR TITLE
ci: onboard the fleet-standard Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge on green Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      # Major bumps are excluded on purpose: they wait for the nightly
+      # retrospective sweep, which verifies the deploy before merging.
+      #
+      # The merge runs on AUTOMERGE_PAT, not GITHUB_TOKEN: pushes made with
+      # GITHUB_TOKEN never trigger other workflows, so a self-merged PR would
+      # silently skip the push-to-main deploy and CI runs. The PAT lives in
+      # both the Actions and Dependabot secret stores (Dependabot-triggered
+      # runs resolve secrets from the Dependabot store). No GITHUB_TOKEN
+      # fallback on purpose: a missing PAT must fail loudly here rather than
+      # quietly restore the deploy-skipping merge path.
+      - name: Require AUTOMERGE_PAT
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AUTOMERGE_PAT is not set in this repo's Dependabot secrets; refusing to merge with GITHUB_TOKEN (its pushes skip deploy/CI triggers)."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
+      - name: Enable auto-merge (patch and minor updates)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}


### PR DESCRIPTION
sigil-attestations has carried a Dependabot config since creation but never received the fleet-standard dependabot-auto-merge.yml, so three green non-major updates (#39, #41, #43) sat stranded: allow_auto_merge was off and AUTOMERGE_PAT was absent from both secret stores. Probe 10 in infra fleet-tools/retro-controls-liveness.sh only verifies prerequisites on repos already carrying the workflow, so this gap was invisible to it by construction (companion infra PR extends the probe).

Prerequisites provisioned this run: allow_auto_merge on, AUTOMERGE_PAT set in the Actions and Dependabot secret stores from GSM sigtel/sigil-github-pat. The active 'Green CI required on main' ruleset requires the Dependency audit check, so the workflow's --auto path defers to green as designed; this repo is not in the instant-merge hazard class the probe's design comment guards against.

Workflow is byte-for-byte the fleet standard from Sigil-Core/agent-hooks. Copy-only CI/workflow addition, no runtime code path; SIGIL_REVIEW_SKIP=1 rationale does not apply to workflow files, so normal checks gate this PR on its exact head. Filed by the scheduled failure-retrospective run, 2026-08-19.