### PR TITLE
docs(sign): Use canonical outcome

### DIFF
--- a/decision-literal-allowlist.json
+++ b/decision-literal-allowlist.json
@@ -12,10 +12,10 @@
   "allowedOccurrences": [
     {
       "path": "docs/sign-README.md",
-      "literal": "APPROVED",
-      "expression": "\"status\": \"APPROVED\",",
+      "literal": "ALLOWED",
+      "expression": "\"status\": \"ALLOWED\",",
       "expectedCount": 1,
-      "reason": "Current Wave 1 Sigil Sign response example; cleanup follows the emitter flip."
+      "reason": "Canonical Sigil Sign response example."
     }
   ]
 }

--- a/docs/sign-README.md
+++ b/docs/sign-README.md
@@ -85,11 +85,11 @@ No execution should occur without a valid attestation.
 
 ---
 
-### Response Schema (Approved)
+### Response Schema (Allowed)
 
 ```json
 {
-  "status": "APPROVED",
+  "status": "ALLOWED",
   "intent_attestation": "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...",
   "message": "Intent verified against warranty.md. Append attestation to transaction calldata."
 }


### PR DESCRIPTION
## Summary

- update the copied Sign response heading and JSON to canonical `ALLOWED`
- update the occurrence-narrow gate allowance at the same semantic location
- leave verifier and CLI behavior unchanged

## Verification

- blocking decision-literal gate: 40 files, 1 classified occurrence, 0 violations
- planted, extensionless, and symlink forced-failure proof
- typecheck
- 5 test files and 95 tests
- build
- packed CLI install and invocation
- JSON parse and `git diff --check`
- maintained README and Sign documentation surfaces: 0 `APPROVED` occurrences

## Scope

Documentation and matching gate metadata only.